### PR TITLE
feat: add A, AAAA, MX, NS, SRV record types

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -168,10 +168,22 @@ func (ts *TunnelServer) wireConfig() turbotunnel.WireConfig {
 
 // effectiveRRType returns the DNS RR type for downstream data.
 func (ts *TunnelServer) effectiveRRType() uint16 {
-	if strings.EqualFold(ts.RecordType, "cname") {
+	switch strings.ToLower(ts.RecordType) {
+	case "a":
+		return dns.RRTypeA
+	case "aaaa":
+		return dns.RRTypeAAAA
+	case "cname":
 		return dns.RRTypeCNAME
+	case "mx":
+		return dns.RRTypeMX
+	case "ns":
+		return dns.RRTypeNS
+	case "srv":
+		return dns.RRTypeSRV
+	default:
+		return dns.RRTypeTXT
 	}
-	return dns.RRTypeTXT
 }
 
 // effectiveMaxQnameLen returns the max QNAME length, applying dnstt defaults.

--- a/client/dns.go
+++ b/client/dns.go
@@ -240,6 +240,33 @@ func dnsResponsePayload(resp *dns.Message, domain dns.Name, rrType uint16) ([]by
 		return nil, true
 	}
 
+	if len(resp.Answer) < 1 {
+		return nil, false
+	}
+
+	// For A/AAAA, collect RDATA from all answer RRs.
+	if rrType == dns.RRTypeA || rrType == dns.RRTypeAAAA {
+		var chunks [][]byte
+		for _, answer := range resp.Answer {
+			if answer.Type != rrType {
+				return nil, false
+			}
+			chunks = append(chunks, answer.Data)
+		}
+		var payload []byte
+		var err error
+		if rrType == dns.RRTypeA {
+			payload, err = dns.DecodeRDataA(chunks)
+		} else {
+			payload, err = dns.DecodeRDataAAAA(chunks)
+		}
+		if err != nil {
+			return nil, false
+		}
+		return payload, false
+	}
+
+	// All other types: single answer RR.
 	if len(resp.Answer) != 1 {
 		return nil, false
 	}
@@ -247,7 +274,6 @@ func dnsResponsePayload(resp *dns.Message, domain dns.Name, rrType uint16) ([]by
 
 	_, ok := answer.Name.TrimSuffix(domain)
 	if !ok {
-		// Not the name we are expecting.
 		return nil, false
 	}
 
@@ -258,8 +284,12 @@ func dnsResponsePayload(resp *dns.Message, domain dns.Name, rrType uint16) ([]by
 	var payload []byte
 	var err error
 	switch rrType {
-	case dns.RRTypeCNAME:
+	case dns.RRTypeCNAME, dns.RRTypeNS:
 		payload, err = dns.DecodeRDataCNAME(answer.Data, domain)
+	case dns.RRTypeMX:
+		payload, err = dns.DecodeRDataMX(answer.Data, domain)
+	case dns.RRTypeSRV:
+		payload, err = dns.DecodeRDataSRV(answer.Data, domain)
 	default:
 		payload, err = dns.DecodeRDataTXT(answer.Data)
 	}

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -46,10 +46,14 @@ var (
 )
 
 const (
-	// https://tools.ietf.org/html/rfc1035#section-3.3.1
-	RRTypeCNAME = 5
 	// https://tools.ietf.org/html/rfc1035#section-3.2.2
-	RRTypeTXT = 16
+	RRTypeA     = 1
+	RRTypeNS    = 2
+	RRTypeCNAME = 5
+	RRTypeMX    = 15
+	RRTypeTXT   = 16
+	RRTypeAAAA  = 28
+	RRTypeSRV   = 33
 	// https://tools.ietf.org/html/rfc6891#section-6.1.1
 	RRTypeOPT = 41
 
@@ -364,25 +368,54 @@ func readRR(r io.ReadSeeker) (RR, error) {
 	if err != nil {
 		return rr, err
 	}
-	if rr.Type == RRTypeCNAME {
-		// CNAME RDATA is a domain name that may contain compression
-		// pointers. Parse it with readName (which follows pointers),
-		// then store the uncompressed wire format in rr.Data.
+	// readRRName is a helper that attempts to parse a compressed name from
+	// RDATA. On failure, it falls back to reading raw bytes.
+	readRRName := func(headerLen int) error {
 		startPos, err := r.Seek(0, io.SeekCurrent)
 		if err != nil {
-			return rr, err
+			return err
+		}
+		// Read any fixed-size header before the name.
+		var header []byte
+		if headerLen > 0 {
+			header = make([]byte, headerLen)
+			if _, err := io.ReadFull(r, header); err != nil {
+				return err
+			}
 		}
 		name, err := readName(r)
 		if err != nil {
-			return rr, err
+			// Fallback: read raw bytes instead.
+			if _, seekErr := r.Seek(startPos, io.SeekStart); seekErr != nil {
+				return seekErr
+			}
+			rr.Data = make([]byte, rdLength)
+			_, err = io.ReadFull(r, rr.Data)
+			return err
 		}
-		rr.Data = name.WireFormat()
+		nameWire := name.WireFormat()
+		rr.Data = make([]byte, headerLen+len(nameWire))
+		copy(rr.Data, header)
+		copy(rr.Data[headerLen:], nameWire)
 		// Ensure reader is positioned past the RDATA.
 		_, err = r.Seek(startPos+int64(rdLength), io.SeekStart)
-		if err != nil {
+		return err
+	}
+
+	switch {
+	case rdLength > 0 && (rr.Type == RRTypeCNAME || rr.Type == RRTypeNS):
+		if err := readRRName(0); err != nil {
 			return rr, err
 		}
-	} else {
+	case rdLength > 2 && rr.Type == RRTypeMX:
+		if err := readRRName(2); err != nil {
+			return rr, err
+		}
+	case rdLength > 6 && rr.Type == RRTypeSRV:
+		if err := readRRName(6); err != nil {
+			return rr, err
+		}
+	default:
 		rr.Data = make([]byte, rdLength)
 		_, err = io.ReadFull(r, rr.Data)
 		if err != nil {
@@ -639,12 +672,9 @@ func EncodeRDataTXT(p []byte) []byte {
 // base32Encoding is a base32 encoding without padding, used for CNAME RDATA.
 var base32Encoding = base32.StdEncoding.WithPadding(base32.NoPadding)
 
-// EncodeRDataCNAME encodes a payload as CNAME RDATA by base32-encoding the
-// payload into DNS name labels and appending the tunnel domain. The result is
-// an uncompressed wire-format domain name suitable for use as RR.Data.
-//
-// https://tools.ietf.org/html/rfc1035#section-3.3.1
-func EncodeRDataCNAME(p []byte, domain Name) ([]byte, error) {
+// encodePayloadAsName base32-encodes a payload into DNS name labels and appends
+// the tunnel domain. Returns the uncompressed wire-format domain name.
+func encodePayloadAsName(p []byte, domain Name) ([]byte, error) {
 	const labelLen = 63
 
 	encoded := make([]byte, base32Encoding.EncodedLen(len(p)))
@@ -668,17 +698,16 @@ func EncodeRDataCNAME(p []byte, domain Name) ([]byte, error) {
 	return name.WireFormat(), nil
 }
 
-// DecodeRDataCNAME decodes CNAME RDATA (uncompressed wire-format domain name)
-// back to the original payload. It strips the tunnel domain suffix, joins the
-// remaining labels, and base32-decodes them.
-func DecodeRDataCNAME(data []byte, domain Name) ([]byte, error) {
+// decodePayloadFromName parses an uncompressed wire-format domain name, strips
+// the tunnel domain suffix, joins the remaining labels, and base32-decodes them.
+func decodePayloadFromName(data []byte, domain Name) ([]byte, error) {
 	name, err := NameFromWireFormat(data)
 	if err != nil {
 		return nil, err
 	}
 	prefix, ok := name.TrimSuffix(domain)
 	if !ok {
-		return nil, fmt.Errorf("CNAME target does not end with domain %s", domain)
+		return nil, fmt.Errorf("name does not end with domain %s", domain)
 	}
 	joined := bytes.ToUpper(bytes.Join(prefix, nil))
 	payload := make([]byte, base32Encoding.DecodedLen(len(joined)))
@@ -687,4 +716,147 @@ func DecodeRDataCNAME(data []byte, domain Name) ([]byte, error) {
 		return nil, err
 	}
 	return payload[:n], nil
+}
+
+// EncodeRDataCNAME encodes a payload as CNAME RDATA.
+// https://tools.ietf.org/html/rfc1035#section-3.3.1
+func EncodeRDataCNAME(p []byte, domain Name) ([]byte, error) {
+	return encodePayloadAsName(p, domain)
+}
+
+// DecodeRDataCNAME decodes CNAME RDATA back to the original payload.
+func DecodeRDataCNAME(data []byte, domain Name) ([]byte, error) {
+	return decodePayloadFromName(data, domain)
+}
+
+// EncodeRDataNS encodes a payload as NS RDATA (identical format to CNAME).
+// https://tools.ietf.org/html/rfc1035#section-3.3.11
+func EncodeRDataNS(p []byte, domain Name) ([]byte, error) {
+	return encodePayloadAsName(p, domain)
+}
+
+// DecodeRDataNS decodes NS RDATA back to the original payload.
+func DecodeRDataNS(data []byte, domain Name) ([]byte, error) {
+	return decodePayloadFromName(data, domain)
+}
+
+// EncodeRDataMX encodes a payload as MX RDATA: [preference:2][exchange:name].
+// https://tools.ietf.org/html/rfc1035#section-3.3.9
+func EncodeRDataMX(p []byte, domain Name) ([]byte, error) {
+	nameWire, err := encodePayloadAsName(p, domain)
+	if err != nil {
+		return nil, err
+	}
+	// Prepend 2-byte preference field (set to 0).
+	rdata := make([]byte, 2+len(nameWire))
+	copy(rdata[2:], nameWire)
+	return rdata, nil
+}
+
+// DecodeRDataMX decodes MX RDATA back to the original payload.
+func DecodeRDataMX(data []byte, domain Name) ([]byte, error) {
+	if len(data) < 2 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	// Skip 2-byte preference field.
+	return decodePayloadFromName(data[2:], domain)
+}
+
+// EncodeRDataSRV encodes a payload as SRV RDATA:
+// [priority:2][weight:2][port:2][target:name].
+// https://tools.ietf.org/html/rfc2782
+func EncodeRDataSRV(p []byte, domain Name) ([]byte, error) {
+	nameWire, err := encodePayloadAsName(p, domain)
+	if err != nil {
+		return nil, err
+	}
+	// Prepend 6-byte header (priority, weight, port — all set to 0).
+	rdata := make([]byte, 6+len(nameWire))
+	copy(rdata[6:], nameWire)
+	return rdata, nil
+}
+
+// DecodeRDataSRV decodes SRV RDATA back to the original payload.
+func DecodeRDataSRV(data []byte, domain Name) ([]byte, error) {
+	if len(data) < 6 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	// Skip 6-byte header.
+	return decodePayloadFromName(data[6:], domain)
+}
+
+// EncodeRDataA encodes a payload as multiple A record RDATA chunks. The payload
+// is prefixed with a 2-byte big-endian length, then split into 4-byte chunks
+// (last chunk zero-padded). Returns a slice of RDATA blobs, one per Answer RR.
+func EncodeRDataA(p []byte) [][]byte {
+	const chunkSize = 4
+	// Prepend 2-byte length header.
+	buf := make([]byte, 2+len(p))
+	binary.BigEndian.PutUint16(buf, uint16(len(p)))
+	copy(buf[2:], p)
+	var chunks [][]byte
+	for len(buf) > 0 {
+		chunk := make([]byte, chunkSize)
+		n := copy(chunk, buf)
+		_ = n
+		buf = buf[min(chunkSize, len(buf)):]
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+// DecodeRDataA decodes multiple A record RDATA chunks back to the original
+// payload by concatenating them and reading the 2-byte length prefix.
+func DecodeRDataA(chunks [][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, chunk := range chunks {
+		buf.Write(chunk)
+	}
+	data := buf.Bytes()
+	if len(data) < 2 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	n := int(binary.BigEndian.Uint16(data))
+	data = data[2:]
+	if len(data) < n {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return data[:n], nil
+}
+
+// EncodeRDataAAAA encodes a payload as multiple AAAA record RDATA chunks. The
+// payload is prefixed with a 2-byte big-endian length, then split into 16-byte
+// chunks (last chunk zero-padded).
+func EncodeRDataAAAA(p []byte) [][]byte {
+	const chunkSize = 16
+	buf := make([]byte, 2+len(p))
+	binary.BigEndian.PutUint16(buf, uint16(len(p)))
+	copy(buf[2:], p)
+	var chunks [][]byte
+	for len(buf) > 0 {
+		chunk := make([]byte, chunkSize)
+		copy(chunk, buf)
+		buf = buf[min(chunkSize, len(buf)):]
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+// DecodeRDataAAAA decodes multiple AAAA record RDATA chunks back to the
+// original payload.
+func DecodeRDataAAAA(chunks [][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, chunk := range chunks {
+		buf.Write(chunk)
+	}
+	data := buf.Bytes()
+	if len(data) < 2 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	n := int(binary.BigEndian.Uint16(data))
+	data = data[2:]
+	if len(data) < n {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return data[:n], nil
 }

--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -699,3 +699,192 @@ func TestReadRRCNAMECompression(t *testing.T) {
 		t.Errorf("CNAME RDATA: got %x, want %x", answer.Data, expectedWire)
 	}
 }
+
+func TestEncodeDecodeRDataNS(t *testing.T) {
+	domain, _ := ParseName("t.example.com")
+	for _, p := range [][]byte{{}, {0x01}, bytes.Repeat([]byte{0xcd}, 80)} {
+		rdata, err := EncodeRDataNS(p, domain)
+		if err != nil {
+			t.Errorf("EncodeRDataNS(%x): %v", p, err)
+			continue
+		}
+		decoded, err := DecodeRDataNS(rdata, domain)
+		if err != nil {
+			t.Errorf("DecodeRDataNS: %v", err)
+			continue
+		}
+		if !bytes.Equal(decoded, p) {
+			t.Errorf("NS round-trip failed for %x: got %x", p, decoded)
+		}
+	}
+}
+
+func TestEncodeDecodeRDataMX(t *testing.T) {
+	domain, _ := ParseName("t.example.com")
+	for _, p := range [][]byte{{}, {0x01}, bytes.Repeat([]byte{0xab}, 80)} {
+		rdata, err := EncodeRDataMX(p, domain)
+		if err != nil {
+			t.Errorf("EncodeRDataMX(%x): %v", p, err)
+			continue
+		}
+		decoded, err := DecodeRDataMX(rdata, domain)
+		if err != nil {
+			t.Errorf("DecodeRDataMX: %v", err)
+			continue
+		}
+		if !bytes.Equal(decoded, p) {
+			t.Errorf("MX round-trip failed for %x: got %x", p, decoded)
+		}
+	}
+}
+
+func TestEncodeDecodeRDataSRV(t *testing.T) {
+	domain, _ := ParseName("t.example.com")
+	for _, p := range [][]byte{{}, {0x01}, bytes.Repeat([]byte{0xef}, 80)} {
+		rdata, err := EncodeRDataSRV(p, domain)
+		if err != nil {
+			t.Errorf("EncodeRDataSRV(%x): %v", p, err)
+			continue
+		}
+		decoded, err := DecodeRDataSRV(rdata, domain)
+		if err != nil {
+			t.Errorf("DecodeRDataSRV: %v", err)
+			continue
+		}
+		if !bytes.Equal(decoded, p) {
+			t.Errorf("SRV round-trip failed for %x: got %x", p, decoded)
+		}
+	}
+}
+
+func TestEncodeDecodeRDataA(t *testing.T) {
+	for _, p := range [][]byte{
+		{},
+		{0x01},
+		{0x01, 0x02, 0x03, 0x04, 0x05},
+		bytes.Repeat([]byte{0xab}, 100),
+	} {
+		chunks := EncodeRDataA(p)
+		for _, chunk := range chunks {
+			if len(chunk) != 4 {
+				t.Errorf("A chunk length %d != 4", len(chunk))
+			}
+		}
+		decoded, err := DecodeRDataA(chunks)
+		if err != nil {
+			t.Errorf("DecodeRDataA: %v", err)
+			continue
+		}
+		if !bytes.Equal(decoded, p) {
+			t.Errorf("A round-trip failed for len=%d: got len=%d", len(p), len(decoded))
+		}
+	}
+}
+
+func TestEncodeDecodeRDataAAAA(t *testing.T) {
+	for _, p := range [][]byte{
+		{},
+		{0x01},
+		bytes.Repeat([]byte{0xab}, 50),
+		bytes.Repeat([]byte{0xcd}, 200),
+	} {
+		chunks := EncodeRDataAAAA(p)
+		for _, chunk := range chunks {
+			if len(chunk) != 16 {
+				t.Errorf("AAAA chunk length %d != 16", len(chunk))
+			}
+		}
+		decoded, err := DecodeRDataAAAA(chunks)
+		if err != nil {
+			t.Errorf("DecodeRDataAAAA: %v", err)
+			continue
+		}
+		if !bytes.Equal(decoded, p) {
+			t.Errorf("AAAA round-trip failed for len=%d: got len=%d", len(p), len(decoded))
+		}
+	}
+}
+
+func TestReadRRMXCompression(t *testing.T) {
+	// DNS message with MX answer using compression pointer in exchange name.
+	msg := []byte{
+		// Header
+		0x00, 0x01, 0x81, 0x80,
+		0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+		// Question: example.com
+		0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+		0x03, 'c', 'o', 'm',
+		0x00,
+		0x00, 0x0f, // QTYPE=MX
+		0x00, 0x01,
+		// Answer: example.com MX 10 mail.example.com
+		0xc0, 0x0c, // compression pointer to example.com
+		0x00, 0x0f, // TYPE=MX
+		0x00, 0x01, // CLASS=IN
+		0x00, 0x00, 0x0e, 0x10, // TTL
+		0x00, 0x09, // RDLENGTH=9
+		// RDATA: preference=10, exchange=mail.example.com (compressed)
+		0x00, 0x0a, // preference
+		0x04, 'm', 'a', 'i', 'l', // label "mail"
+		0xc0, 0x0c, // compression pointer to example.com
+	}
+
+	parsed, err := MessageFromWireFormat(msg)
+	if err != nil {
+		t.Fatalf("MessageFromWireFormat: %v", err)
+	}
+	if len(parsed.Answer) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(parsed.Answer))
+	}
+	answer := parsed.Answer[0]
+	if answer.Type != RRTypeMX {
+		t.Fatalf("expected MX type, got %d", answer.Type)
+	}
+	// Data should be: preference(2) + uncompressed wire format of "mail.example.com"
+	expectedName := Name([][]byte{[]byte("mail"), []byte("example"), []byte("com")})
+	expectedData := append([]byte{0x00, 0x0a}, expectedName.WireFormat()...)
+	if !bytes.Equal(answer.Data, expectedData) {
+		t.Errorf("MX RDATA: got %x, want %x", answer.Data, expectedData)
+	}
+}
+
+func TestReadRRSRVCompression(t *testing.T) {
+	// DNS message with SRV answer using compression pointer in target name.
+	msg := []byte{
+		// Header
+		0x00, 0x01, 0x81, 0x80,
+		0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+		// Question: example.com
+		0x07, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+		0x03, 'c', 'o', 'm',
+		0x00,
+		0x00, 0x21, // QTYPE=SRV
+		0x00, 0x01,
+		// Answer: example.com SRV 0 0 443 web.example.com
+		0xc0, 0x0c,
+		0x00, 0x21, // TYPE=SRV
+		0x00, 0x01,
+		0x00, 0x00, 0x0e, 0x10,
+		0x00, 0x0c, // RDLENGTH=12
+		// RDATA
+		0x00, 0x00, // priority
+		0x00, 0x00, // weight
+		0x01, 0xbb, // port=443
+		0x03, 'w', 'e', 'b', // label "web"
+		0xc0, 0x0c, // compression pointer
+	}
+
+	parsed, err := MessageFromWireFormat(msg)
+	if err != nil {
+		t.Fatalf("MessageFromWireFormat: %v", err)
+	}
+	answer := parsed.Answer[0]
+	if answer.Type != RRTypeSRV {
+		t.Fatalf("expected SRV type, got %d", answer.Type)
+	}
+	expectedName := Name([][]byte{[]byte("web"), []byte("example"), []byte("com")})
+	expectedData := append([]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0xbb}, expectedName.WireFormat()...)
+	if !bytes.Equal(answer.Data, expectedData) {
+		t.Errorf("SRV RDATA: got %x, want %x", answer.Data, expectedData)
+	}
+}

--- a/e2e/run-test.sh
+++ b/e2e/run-test.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 failed=0
 total=0
 
-for test_dir in tunnel-txt tunnel-cname socks-download recovery; do
+for test_dir in tunnel-txt tunnel-cname tunnel-a tunnel-aaaa tunnel-mx tunnel-ns tunnel-srv socks-download recovery; do
     total=$((total + 1))
     echo ""
     echo "========================================"

--- a/e2e/tunnel-a/docker-compose.yml
+++ b/e2e/tunnel-a/docker-compose.yml
@@ -1,0 +1,67 @@
+networks:
+  dns-net:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+  backend-net:
+
+volumes:
+  keys:
+
+services:
+  keygen:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    volumes:
+      - keys:/keys
+    command: >
+      sh -c "vaydns-server -gen-key -privkey-file /keys/server.key -pubkey-file /keys/server.pub"
+
+  dns:
+    image: coredns/coredns
+    networks:
+      dns-net:
+        ipv4_address: 172.28.0.10
+    volumes:
+      - ../Corefile:/Corefile
+    command: ["-conf", "/Corefile"]
+
+  backend:
+    image: nginx:alpine
+    networks:
+      - backend-net
+
+  server:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    networks:
+      dns-net:
+        ipv4_address: 172.28.0.20
+      backend-net:
+    volumes:
+      - keys:/keys
+    command: >
+      vaydns-server -udp :53 -privkey-file /keys/server.key
+      -domain t.example.com -upstream backend:80 -record-type a
+    depends_on:
+      keygen:
+        condition: service_completed_successfully
+      dns:
+        condition: service_started
+
+  client:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    networks:
+      - dns-net
+    volumes:
+      - keys:/keys
+    command: >
+      vaydns-client -udp 172.28.0.10:53 -pubkey-file /keys/server.pub
+      -domain t.example.com -listen 0.0.0.0:7000 -record-type a
+    depends_on:
+      server:
+        condition: service_started

--- a/e2e/tunnel-a/run.sh
+++ b/e2e/tunnel-a/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Test: A record tunnel — client fetches nginx page through DNS tunnel using A records
+set -euo pipefail
+cd "$(dirname "$0")"
+
+cleanup() { docker compose down -v 2>/dev/null; }
+trap cleanup EXIT
+
+echo "--- Building and starting services ---"
+docker compose up -d --build
+
+echo "--- Waiting for tunnel (up to 30s) ---"
+for i in $(seq 1 30); do
+    if docker compose exec -T client wget -q -O- http://localhost:7000 2>/dev/null | grep -q "Welcome to nginx"; then
+        echo ""
+        echo "=== PASS ==="
+        exit 0
+    fi
+    printf "."
+    sleep 1
+done
+
+echo ""
+echo "--- Tunnel did not come up. Dumping logs ---"
+docker compose logs client server
+echo "=== FAIL ==="
+exit 1

--- a/e2e/tunnel-aaaa/docker-compose.yml
+++ b/e2e/tunnel-aaaa/docker-compose.yml
@@ -1,0 +1,67 @@
+networks:
+  dns-net:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+  backend-net:
+
+volumes:
+  keys:
+
+services:
+  keygen:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    volumes:
+      - keys:/keys
+    command: >
+      sh -c "vaydns-server -gen-key -privkey-file /keys/server.key -pubkey-file /keys/server.pub"
+
+  dns:
+    image: coredns/coredns
+    networks:
+      dns-net:
+        ipv4_address: 172.28.0.10
+    volumes:
+      - ../Corefile:/Corefile
+    command: ["-conf", "/Corefile"]
+
+  backend:
+    image: nginx:alpine
+    networks:
+      - backend-net
+
+  server:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    networks:
+      dns-net:
+        ipv4_address: 172.28.0.20
+      backend-net:
+    volumes:
+      - keys:/keys
+    command: >
+      vaydns-server -udp :53 -privkey-file /keys/server.key
+      -domain t.example.com -upstream backend:80 -record-type aaaa
+    depends_on:
+      keygen:
+        condition: service_completed_successfully
+      dns:
+        condition: service_started
+
+  client:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    networks:
+      - dns-net
+    volumes:
+      - keys:/keys
+    command: >
+      vaydns-client -udp 172.28.0.10:53 -pubkey-file /keys/server.pub
+      -domain t.example.com -listen 0.0.0.0:7000 -record-type aaaa
+    depends_on:
+      server:
+        condition: service_started

--- a/e2e/tunnel-aaaa/run.sh
+++ b/e2e/tunnel-aaaa/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Test: AAAA record tunnel — client fetches nginx page through DNS tunnel using AAAA records
+set -euo pipefail
+cd "$(dirname "$0")"
+
+cleanup() { docker compose down -v 2>/dev/null; }
+trap cleanup EXIT
+
+echo "--- Building and starting services ---"
+docker compose up -d --build
+
+echo "--- Waiting for tunnel (up to 30s) ---"
+for i in $(seq 1 30); do
+    if docker compose exec -T client wget -q -O- http://localhost:7000 2>/dev/null | grep -q "Welcome to nginx"; then
+        echo ""
+        echo "=== PASS ==="
+        exit 0
+    fi
+    printf "."
+    sleep 1
+done
+
+echo ""
+echo "--- Tunnel did not come up. Dumping logs ---"
+docker compose logs client server
+echo "=== FAIL ==="
+exit 1

--- a/e2e/tunnel-mx/docker-compose.yml
+++ b/e2e/tunnel-mx/docker-compose.yml
@@ -1,0 +1,67 @@
+networks:
+  dns-net:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+  backend-net:
+
+volumes:
+  keys:
+
+services:
+  keygen:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    volumes:
+      - keys:/keys
+    command: >
+      sh -c "vaydns-server -gen-key -privkey-file /keys/server.key -pubkey-file /keys/server.pub"
+
+  dns:
+    image: coredns/coredns
+    networks:
+      dns-net:
+        ipv4_address: 172.28.0.10
+    volumes:
+      - ../Corefile:/Corefile
+    command: ["-conf", "/Corefile"]
+
+  backend:
+    image: nginx:alpine
+    networks:
+      - backend-net
+
+  server:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    networks:
+      dns-net:
+        ipv4_address: 172.28.0.20
+      backend-net:
+    volumes:
+      - keys:/keys
+    command: >
+      vaydns-server -udp :53 -privkey-file /keys/server.key
+      -domain t.example.com -upstream backend:80 -record-type mx
+    depends_on:
+      keygen:
+        condition: service_completed_successfully
+      dns:
+        condition: service_started
+
+  client:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    networks:
+      - dns-net
+    volumes:
+      - keys:/keys
+    command: >
+      vaydns-client -udp 172.28.0.10:53 -pubkey-file /keys/server.pub
+      -domain t.example.com -listen 0.0.0.0:7000 -record-type mx
+    depends_on:
+      server:
+        condition: service_started

--- a/e2e/tunnel-mx/run.sh
+++ b/e2e/tunnel-mx/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Test: MX record tunnel — client fetches nginx page through DNS tunnel using MX records
+set -euo pipefail
+cd "$(dirname "$0")"
+
+cleanup() { docker compose down -v 2>/dev/null; }
+trap cleanup EXIT
+
+echo "--- Building and starting services ---"
+docker compose up -d --build
+
+echo "--- Waiting for tunnel (up to 30s) ---"
+for i in $(seq 1 30); do
+    if docker compose exec -T client wget -q -O- http://localhost:7000 2>/dev/null | grep -q "Welcome to nginx"; then
+        echo ""
+        echo "=== PASS ==="
+        exit 0
+    fi
+    printf "."
+    sleep 1
+done
+
+echo ""
+echo "--- Tunnel did not come up. Dumping logs ---"
+docker compose logs client server
+echo "=== FAIL ==="
+exit 1

--- a/e2e/tunnel-ns/docker-compose.yml
+++ b/e2e/tunnel-ns/docker-compose.yml
@@ -1,0 +1,67 @@
+networks:
+  dns-net:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+  backend-net:
+
+volumes:
+  keys:
+
+services:
+  keygen:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    volumes:
+      - keys:/keys
+    command: >
+      sh -c "vaydns-server -gen-key -privkey-file /keys/server.key -pubkey-file /keys/server.pub"
+
+  dns:
+    image: coredns/coredns
+    networks:
+      dns-net:
+        ipv4_address: 172.28.0.10
+    volumes:
+      - ../Corefile:/Corefile
+    command: ["-conf", "/Corefile"]
+
+  backend:
+    image: nginx:alpine
+    networks:
+      - backend-net
+
+  server:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    networks:
+      dns-net:
+        ipv4_address: 172.28.0.20
+      backend-net:
+    volumes:
+      - keys:/keys
+    command: >
+      vaydns-server -udp :53 -privkey-file /keys/server.key
+      -domain t.example.com -upstream backend:80 -record-type ns
+    depends_on:
+      keygen:
+        condition: service_completed_successfully
+      dns:
+        condition: service_started
+
+  client:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    networks:
+      - dns-net
+    volumes:
+      - keys:/keys
+    command: >
+      vaydns-client -udp 172.28.0.10:53 -pubkey-file /keys/server.pub
+      -domain t.example.com -listen 0.0.0.0:7000 -record-type ns
+    depends_on:
+      server:
+        condition: service_started

--- a/e2e/tunnel-ns/run.sh
+++ b/e2e/tunnel-ns/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Test: NS record tunnel — client fetches nginx page through DNS tunnel using NS records
+set -euo pipefail
+cd "$(dirname "$0")"
+
+cleanup() { docker compose down -v 2>/dev/null; }
+trap cleanup EXIT
+
+echo "--- Building and starting services ---"
+docker compose up -d --build
+
+echo "--- Waiting for tunnel (up to 30s) ---"
+for i in $(seq 1 30); do
+    if docker compose exec -T client wget -q -O- http://localhost:7000 2>/dev/null | grep -q "Welcome to nginx"; then
+        echo ""
+        echo "=== PASS ==="
+        exit 0
+    fi
+    printf "."
+    sleep 1
+done
+
+echo ""
+echo "--- Tunnel did not come up. Dumping logs ---"
+docker compose logs client server
+echo "=== FAIL ==="
+exit 1

--- a/e2e/tunnel-srv/docker-compose.yml
+++ b/e2e/tunnel-srv/docker-compose.yml
@@ -1,0 +1,67 @@
+networks:
+  dns-net:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+  backend-net:
+
+volumes:
+  keys:
+
+services:
+  keygen:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    volumes:
+      - keys:/keys
+    command: >
+      sh -c "vaydns-server -gen-key -privkey-file /keys/server.key -pubkey-file /keys/server.pub"
+
+  dns:
+    image: coredns/coredns
+    networks:
+      dns-net:
+        ipv4_address: 172.28.0.10
+    volumes:
+      - ../Corefile:/Corefile
+    command: ["-conf", "/Corefile"]
+
+  backend:
+    image: nginx:alpine
+    networks:
+      - backend-net
+
+  server:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    networks:
+      dns-net:
+        ipv4_address: 172.28.0.20
+      backend-net:
+    volumes:
+      - keys:/keys
+    command: >
+      vaydns-server -udp :53 -privkey-file /keys/server.key
+      -domain t.example.com -upstream backend:80 -record-type srv
+    depends_on:
+      keygen:
+        condition: service_completed_successfully
+      dns:
+        condition: service_started
+
+  client:
+    build:
+      context: ../..
+      dockerfile: e2e/Dockerfile
+    networks:
+      - dns-net
+    volumes:
+      - keys:/keys
+    command: >
+      vaydns-client -udp 172.28.0.10:53 -pubkey-file /keys/server.pub
+      -domain t.example.com -listen 0.0.0.0:7000 -record-type srv
+    depends_on:
+      server:
+        condition: service_started

--- a/e2e/tunnel-srv/run.sh
+++ b/e2e/tunnel-srv/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Test: SRV record tunnel — client fetches nginx page through DNS tunnel using SRV records
+set -euo pipefail
+cd "$(dirname "$0")"
+
+cleanup() { docker compose down -v 2>/dev/null; }
+trap cleanup EXIT
+
+echo "--- Building and starting services ---"
+docker compose up -d --build
+
+echo "--- Waiting for tunnel (up to 30s) ---"
+for i in $(seq 1 30); do
+    if docker compose exec -T client wget -q -O- http://localhost:7000 2>/dev/null | grep -q "Welcome to nginx"; then
+        echo ""
+        echo "=== PASS ==="
+        exit 0
+    fi
+    printf "."
+    sleep 1
+done
+
+echo ""
+echo "--- Tunnel did not come up. Dumping logs ---"
+docker compose logs client server
+echo "=== FAIL ==="
+exit 1

--- a/vaydns-client/main.go
+++ b/vaydns-client/main.go
@@ -112,7 +112,7 @@ Known TLS fingerprints for -utls are:
 	flag.BoolVar(&udpAcceptErrors, "udp-accept-errors", false, "accept DNS error responses instead of filtering them (disables censorship evasion)")
 	flag.BoolVar(&compatDnstt, "dnstt-compat", false, "use original dnstt wire format (8-byte ClientID, padding prefixes)")
 	flag.IntVar(&clientIDSize, "clientid-size", 2, "client ID size in bytes (ignored when -dnstt-compat is set)")
-	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt or cname)")
+	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt, cname, a, aaaa, mx, ns, srv)")
 
 	var logLevel string
 	flag.StringVar(&logLevel, "log-level", "warning", "log level (debug, info, warning, error)")
@@ -142,10 +142,10 @@ Known TLS fingerprints for -utls are:
 	log.Infof("using domain: %s", domainArg)
 
 	switch strings.ToLower(recordTypeStr) {
-	case "txt", "cname":
+	case "txt", "cname", "a", "aaaa", "mx", "ns", "srv":
 		recordTypeStr = strings.ToLower(recordTypeStr)
 	default:
-		fmt.Fprintf(os.Stderr, "invalid -record-type %q: must be \"txt\" or \"cname\"\n", recordTypeStr)
+		fmt.Fprintf(os.Stderr, "invalid -record-type %q: must be one of: txt, cname, a, aaaa, mx, ns, srv\n", recordTypeStr)
 		os.Exit(1)
 	}
 	log.Infof("record type: %s", recordTypeStr)
@@ -269,8 +269,8 @@ Known TLS fingerprints for -utls are:
 
 	// Apply -dnstt-compat overrides.
 	if compatDnstt {
-		if recordTypeStr == "cname" {
-			fmt.Fprintf(os.Stderr, "-dnstt-compat is not compatible with -record-type cname; dnstt only supports TXT records\n")
+		if recordTypeStr != "txt" {
+			fmt.Fprintf(os.Stderr, "-dnstt-compat is not compatible with -record-type %s; dnstt only supports TXT records\n", recordTypeStr)
 			os.Exit(1)
 		}
 		explicitFlags := make(map[string]bool)

--- a/vaydns-server/main.go
+++ b/vaydns-server/main.go
@@ -497,7 +497,7 @@ func responseFor(query *dns.Message, domain dns.Name) (*dns.Message, []byte) {
 	}
 
 	if question.Type != recordType {
-		// We only support the configured QTYPE (TXT or CNAME).
+		// We only support the configured QTYPE.
 		resp.Flags |= dns.RcodeNameError
 		// No log message here; it's common for recursive resolvers to
 		// send NS or A queries when the client only asked for a TXT. I
@@ -839,14 +839,47 @@ func sendLoop(dnsConn net.PacketConn, ttConn *turbotunnel.QueuePacketConn, ch <-
 			}
 			timer.Stop()
 
-			if rec.Resp.Question[0].Type == dns.RRTypeCNAME {
+			switch rec.Resp.Question[0].Type {
+			case dns.RRTypeA, dns.RRTypeAAAA:
+				// A/AAAA: split payload into multiple answer RRs.
+				var chunks [][]byte
+				if rec.Resp.Question[0].Type == dns.RRTypeA {
+					chunks = dns.EncodeRDataA(payload.Bytes())
+				} else {
+					chunks = dns.EncodeRDataAAAA(payload.Bytes())
+				}
+				rec.Resp.Answer = make([]dns.RR, len(chunks))
+				for i, chunk := range chunks {
+					rec.Resp.Answer[i] = dns.RR{
+						Name:  rec.Resp.Question[0].Name,
+						Type:  rec.Resp.Question[0].Type,
+						Class: rec.Resp.Question[0].Class,
+						TTL:   responseTTL,
+						Data:  chunk,
+					}
+				}
+			case dns.RRTypeCNAME, dns.RRTypeNS:
 				data, err := dns.EncodeRDataCNAME(payload.Bytes(), domain)
 				if err != nil {
-					log.Errorf("EncodeRDataCNAME: %v", err)
+					log.Errorf("EncodeRData: %v", err)
 					continue
 				}
 				rec.Resp.Answer[0].Data = data
-			} else {
+			case dns.RRTypeMX:
+				data, err := dns.EncodeRDataMX(payload.Bytes(), domain)
+				if err != nil {
+					log.Errorf("EncodeRDataMX: %v", err)
+					continue
+				}
+				rec.Resp.Answer[0].Data = data
+			case dns.RRTypeSRV:
+				data, err := dns.EncodeRDataSRV(payload.Bytes(), domain)
+				if err != nil {
+					log.Errorf("EncodeRDataSRV: %v", err)
+					continue
+				}
+				rec.Resp.Answer[0].Data = data
+			default:
 				rec.Resp.Answer[0].Data = dns.EncodeRDataTXT(payload.Bytes())
 			}
 		}
@@ -969,12 +1002,11 @@ func computeMaxEncodedPayload(limit int) int {
 	return low
 }
 
-// computeMaxEncodedPayloadCNAME computes the maximum raw payload bytes that can
-// fit in a CNAME RDATA domain name, given the tunnel domain. CNAME RDATA is a
-// single DNS name (max 255 wire bytes). The payload is base32-encoded and split
-// into labels.
-func computeMaxEncodedPayloadCNAME(domain dns.Name) int {
-	// Calculate domain wire length.
+// computeMaxEncodedPayloadNameBased computes the maximum raw payload bytes that
+// can fit in a name-based RDATA (CNAME, NS, MX, SRV). headerOverhead is the
+// number of fixed bytes before the domain name in the RDATA (0 for CNAME/NS,
+// 2 for MX, 6 for SRV).
+func computeMaxEncodedPayloadNameBased(domain dns.Name, headerOverhead int) int {
 	domainWireLen := 1 // null terminator
 	for _, label := range domain {
 		domainWireLen += 1 + len(label)
@@ -983,11 +1015,77 @@ func computeMaxEncodedPayloadCNAME(domain dns.Name) int {
 	if available <= 0 {
 		return 0
 	}
-	// Each label uses 1 length byte + up to 63 content bytes.
-	// Number of full labels that fit.
 	encodedBytes := available * 63 / 64
-	// Base32 decode: 8 encoded chars → 5 raw bytes.
 	return encodedBytes * 5 / 8
+}
+
+// computeMaxEncodedPayloadMultiRR computes the maximum raw payload bytes that
+// can fit in multiple fixed-size RRs (A=4 bytes, AAAA=16 bytes) within a DNS
+// response of at most limit bytes. Uses binary search like the TXT computation.
+func computeMaxEncodedPayloadMultiRR(limit int, chunkSize int) int {
+	maxLengthName, err := dns.NewName([][]byte{
+		[]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+		[]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+		[]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+		[]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	queryLimit := uint16(limit)
+	if int(queryLimit) != limit {
+		queryLimit = 0xffff
+	}
+	query := &dns.Message{
+		Question: []dns.Question{
+			{
+				Name:  maxLengthName,
+				Type:  recordType,
+				Class: dns.ClassIN,
+			},
+		},
+		Additional: []dns.RR{
+			{
+				Name:  dns.Name{},
+				Type:  dns.RRTypeOPT,
+				Class: queryLimit,
+				TTL:   0,
+				Data:  []byte{},
+			},
+		},
+	}
+	resp, _ := responseFor(query, dns.Name([][]byte{}))
+
+	// Binary search: find max payload that fits when split into chunkSize RRs.
+	low := 0
+	high := 32768
+	for low+1 < high {
+		mid := (low + high) / 2
+		// Simulate encoding: 2-byte length prefix + payload → ceil((2+mid)/chunkSize) RRs.
+		totalBytes := 2 + mid
+		numChunks := (totalBytes + chunkSize - 1) / chunkSize
+		resp.Answer = make([]dns.RR, numChunks)
+		for i := range numChunks {
+			resp.Answer[i] = dns.RR{
+				Name:  query.Question[0].Name,
+				Type:  query.Question[0].Type,
+				Class: query.Question[0].Class,
+				TTL:   responseTTL,
+				Data:  make([]byte, chunkSize),
+			}
+		}
+		buf, err := resp.WireFormat()
+		if err != nil {
+			panic(err)
+		}
+		if len(buf) <= limit {
+			low = mid
+		} else {
+			high = mid
+		}
+	}
+	return low
 }
 
 func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketConn, fallbackAddr *net.UDPAddr, idleTimeout time.Duration, keepAlive time.Duration, wireConfig turbotunnel.WireConfig) error {
@@ -1003,9 +1101,18 @@ func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketCon
 	// keep the UDP payload size under maxUDPPayload, even in the worst case
 	// of a maximum-length name in the query's Question section.
 	var maxEncodedPayload int
-	if recordType == dns.RRTypeCNAME {
-		maxEncodedPayload = computeMaxEncodedPayloadCNAME(domain)
-	} else {
+	switch recordType {
+	case dns.RRTypeCNAME, dns.RRTypeNS:
+		maxEncodedPayload = computeMaxEncodedPayloadNameBased(domain, 0)
+	case dns.RRTypeMX:
+		maxEncodedPayload = computeMaxEncodedPayloadNameBased(domain, 2)
+	case dns.RRTypeSRV:
+		maxEncodedPayload = computeMaxEncodedPayloadNameBased(domain, 6)
+	case dns.RRTypeA:
+		maxEncodedPayload = computeMaxEncodedPayloadMultiRR(maxUDPPayload, 4)
+	case dns.RRTypeAAAA:
+		maxEncodedPayload = computeMaxEncodedPayloadMultiRR(maxUDPPayload, 16)
+	default:
 		maxEncodedPayload = computeMaxEncodedPayload(maxUDPPayload)
 	}
 	// 2 bytes accounts for a packet length prefix.
@@ -1109,7 +1216,7 @@ Example:
 	flag.StringVar(&keepAliveStr, "keepalive", defaultKeepAlive.String(), "keepalive ping interval (e.g. 2s, 500ms); must be less than idle-timeout")
 	flag.BoolVar(&compatDnstt, "dnstt-compat", false, "use original dnstt wire format (8-byte ClientID, padding prefixes)")
 	flag.IntVar(&clientIDSize, "clientid-size", 2, "client ID size in bytes (ignored when -dnstt-compat is set)")
-	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt or cname)")
+	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt, cname, a, aaaa, mx, ns, srv)")
 
 	var logLevel string
 	flag.StringVar(&logLevel, "log-level", "warning", "log level (debug, info, warning, error)")
@@ -1128,8 +1235,18 @@ Example:
 		recordType = dns.RRTypeTXT
 	case "cname":
 		recordType = dns.RRTypeCNAME
+	case "a":
+		recordType = dns.RRTypeA
+	case "aaaa":
+		recordType = dns.RRTypeAAAA
+	case "mx":
+		recordType = dns.RRTypeMX
+	case "ns":
+		recordType = dns.RRTypeNS
+	case "srv":
+		recordType = dns.RRTypeSRV
 	default:
-		fmt.Fprintf(os.Stderr, "invalid -record-type %q: must be \"txt\" or \"cname\"\n", recordTypeStr)
+		fmt.Fprintf(os.Stderr, "invalid -record-type %q: must be one of: txt, cname, a, aaaa, mx, ns, srv\n", recordTypeStr)
 		os.Exit(1)
 	}
 
@@ -1264,8 +1381,8 @@ Example:
 
 		var wireConfig turbotunnel.WireConfig
 		if compatDnstt {
-			if recordType == dns.RRTypeCNAME {
-				fmt.Fprintf(os.Stderr, "-dnstt-compat is not compatible with -record-type cname; dnstt only supports TXT records\n")
+			if recordType != dns.RRTypeTXT {
+				fmt.Fprintf(os.Stderr, "-dnstt-compat is not compatible with -record-type %s; dnstt only supports TXT records\n", recordTypeStr)
 				os.Exit(1)
 			}
 			wireConfig = turbotunnel.WireConfig{ClientIDSize: 8, Compat: true}
@@ -1295,13 +1412,13 @@ Example:
 		}
 		log.Infof("wire config: clientid-size=%d compat=%v", wireConfig.ClientIDSize, wireConfig.Compat)
 
-		if recordType == dns.RRTypeCNAME {
+		if recordType == dns.RRTypeCNAME || recordType == dns.RRTypeNS || recordType == dns.RRTypeMX || recordType == dns.RRTypeSRV {
 			explicitFlags := make(map[string]bool)
 			flag.Visit(func(f *flag.Flag) {
 				explicitFlags[f.Name] = true
 			})
 			if explicitFlags["mtu"] {
-				log.Warnf("-mtu has no effect with -record-type cname; CNAME capacity is bounded by the DNS name length limit (255 bytes)")
+				log.Warnf("-mtu has no effect with -record-type %s; capacity is bounded by the DNS name length limit (255 bytes)", recordTypeStr)
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Add 5 new DNS record types for downstream tunnel data: A, AAAA, MX, NS, SRV
- Two encoding families:
  - **Name-based** (NS, MX, SRV): base32 payload in DNS name labels (same as CNAME), ~141-147 bytes/response
  - **Multi-RR** (A, AAAA): payload split across multiple answer RRs (4 or 16 bytes each)
- Handle RDATA compression pointers from intermediate resolvers for NS/MX/SRV
- Extend `-record-type` flag to accept: `txt`, `cname`, `a`, `aaaa`, `mx`, `ns`, `srv`
- Reject `-dnstt-compat` with all non-TXT types (not just CNAME)
- E2E tests for each new record type

Builds on #33

## Test plan
- [x] Unit tests: `go test ./dns/...` — round-trip encode/decode for all types, compression pointer handling
- [x] All tests: `go test ./...` — no regressions
- [x] E2E A: `bash e2e/tunnel-a/run.sh` — PASS
- [x] E2E AAAA: `bash e2e/tunnel-aaaa/run.sh` — PASS
- [x] E2E MX: `bash e2e/tunnel-mx/run.sh` — PASS
- [x] E2E NS: `bash e2e/tunnel-ns/run.sh` — PASS
- [x] E2E SRV: `bash e2e/tunnel-srv/run.sh` — PASS
