### PR TITLE
client: harden recovery and add runtime transport sizing for session reliability

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -54,7 +54,8 @@ const (
 )
 
 const (
-	DefaultPacketQueueSize = turbotunnel.DefaultQueueSize
+	DefaultPacketQueueSize   = turbotunnel.DefaultQueueSize
+	DefaultQueueOverflowMode = turbotunnel.DefaultQueueOverflowMode
 )
 
 // Default timeouts for dnstt compatibility mode.
@@ -198,16 +199,17 @@ type Tunnel struct {
 	TunnelServer TunnelServer
 
 	// Session configuration. Zero values use defaults.
-	IdleTimeout          time.Duration // default: 10s (2m with DnsttCompat)
-	KeepAlive            time.Duration // default: 2s (10s with DnsttCompat)
-	OpenStreamTimeout    time.Duration // default: 10s
-	MaxStreams           int           // default: 256 (0 = unlimited)
-	ReconnectMinDelay    time.Duration // default: 1s
-	ReconnectMaxDelay    time.Duration // default: 30s
-	SessionCheckInterval time.Duration // default: 20s
-	HandshakeTimeout     time.Duration // default: 30s
-	PacketQueueSize      int           // default: 1024
-	KCPWindowSize        int           // default: PacketQueueSize/2
+	IdleTimeout          time.Duration                 // default: 10s (2m with DnsttCompat)
+	KeepAlive            time.Duration                 // default: 2s (10s with DnsttCompat)
+	OpenStreamTimeout    time.Duration                 // default: 10s
+	MaxStreams           int                           // default: 256 (0 = unlimited)
+	ReconnectMinDelay    time.Duration                 // default: 1s
+	ReconnectMaxDelay    time.Duration                 // default: 30s
+	SessionCheckInterval time.Duration                 // default: 20s
+	HandshakeTimeout     time.Duration                 // default: 30s
+	PacketQueueSize      int                           // default: 1024
+	KCPWindowSize        int                           // default: PacketQueueSize/2
+	QueueOverflowMode    turbotunnel.QueueOverflowMode // default: drop
 
 	// internal state
 	wireConfig    turbotunnel.WireConfig
@@ -266,15 +268,6 @@ func (t *Tunnel) applyDefaults() {
 	if t.HandshakeTimeout == 0 {
 		t.HandshakeTimeout = DefaultHandshakeTimeout
 	}
-	if t.PacketQueueSize == 0 {
-		t.PacketQueueSize = DefaultPacketQueueSize
-	}
-	if t.KCPWindowSize == 0 {
-		t.KCPWindowSize = t.PacketQueueSize / 2
-		if t.KCPWindowSize < 1 {
-			t.KCPWindowSize = 1
-		}
-	}
 }
 
 func (t *Tunnel) effectivePacketQueueSize() int {
@@ -282,6 +275,20 @@ func (t *Tunnel) effectivePacketQueueSize() int {
 		return t.PacketQueueSize
 	}
 	return DefaultPacketQueueSize
+}
+
+func (t *Tunnel) effectiveQueueOverflowMode() turbotunnel.QueueOverflowMode {
+	if t.QueueOverflowMode != "" {
+		return t.QueueOverflowMode
+	}
+	return DefaultQueueOverflowMode
+}
+
+func (t *Tunnel) effectiveQueuePacketConnConfig() turbotunnel.QueuePacketConnConfig {
+	return turbotunnel.QueuePacketConnConfig{
+		QueueSize:    t.effectivePacketQueueSize(),
+		OverflowMode: t.effectiveQueueOverflowMode(),
+	}
 }
 
 func (t *Tunnel) effectiveKCPWindowSize() int {
@@ -299,7 +306,7 @@ func (t *Tunnel) effectiveKCPWindowSize() int {
 // based on the Resolver configuration.
 func (t *Tunnel) InitiateResolverConnection() error {
 	r := t.Resolver
-	queueSize := t.effectivePacketQueueSize()
+	queueConfig := t.effectiveQueuePacketConnConfig()
 	switch r.ResolverType {
 	case ResolverTypeUDP:
 		addr, err := net.ResolveUDPAddr("udp", r.ResolverAddr)
@@ -323,7 +330,7 @@ func (t *Tunnel) InitiateResolverConnection() error {
 			if timeout <= 0 {
 				timeout = DefaultUDPResponseTimeout
 			}
-			conn, forgedStats, err := NewUDPPacketConnWithQueueSize(addr, r.DialerControl, workers, timeout, !r.UDPAcceptErrors, queueSize)
+			conn, forgedStats, err := NewUDPPacketConnWithQueueConfig(addr, r.DialerControl, workers, timeout, !r.UDPAcceptErrors, queueConfig)
 			if err != nil {
 				return err
 			}
@@ -342,7 +349,7 @@ func (t *Tunnel) InitiateResolverConnection() error {
 		} else {
 			rt = http.DefaultTransport
 		}
-		conn, err := NewHTTPPacketConnWithQueueSize(rt, r.ResolverAddr, 8, queueSize)
+		conn, err := NewHTTPPacketConnWithQueueConfig(rt, r.ResolverAddr, 8, queueConfig)
 		if err != nil {
 			return err
 		}
@@ -362,7 +369,7 @@ func (t *Tunnel) InitiateResolverConnection() error {
 				return tls.DialWithDialer(&net.Dialer{}, network, addr, nil)
 			}
 		}
-		conn, err := NewTLSPacketConnWithQueueSize(r.ResolverAddr, dialTLSContext, queueSize)
+		conn, err := NewTLSPacketConnWithQueueConfig(r.ResolverAddr, dialTLSContext, queueConfig)
 		if err != nil {
 			return err
 		}
@@ -382,7 +389,7 @@ func (t *Tunnel) InitiateDNSPacketConn(domain dns.Name) error {
 	}
 	maxQnameLen := t.TunnelServer.effectiveMaxQnameLen()
 	rrType := t.TunnelServer.effectiveRRType()
-	t.dnsPacketConn = NewDNSPacketConnWithQueueSize(t.resolverConn, t.remoteAddr, domain, rateLimiter, maxQnameLen, t.TunnelServer.MaxNumLabels, t.wireConfig, t.forgedStats, rrType, t.effectivePacketQueueSize())
+	t.dnsPacketConn = NewDNSPacketConnWithQueueConfig(t.resolverConn, t.remoteAddr, domain, rateLimiter, maxQnameLen, t.TunnelServer.MaxNumLabels, t.wireConfig, t.forgedStats, rrType, t.effectiveQueuePacketConnConfig())
 	return nil
 }
 
@@ -710,9 +717,8 @@ func (t *Tunnel) ListenAndServe(listenAddr string) error {
 
 			localTCP := local.(*net.TCPConn)
 			sessRef := sess
-			connRef := conn
 			convRef := conv
-			go func(local *net.TCPConn, sess *smux.Session, conn *kcp.UDPSession, conv uint32) {
+			go func(local *net.TCPConn, sess *smux.Session, conv uint32) {
 				if sem != nil {
 					sem <- struct{}{}
 					defer func() { <-sem }()
@@ -722,7 +728,7 @@ func (t *Tunnel) ListenAndServe(listenAddr string) error {
 				if err != nil {
 					log.Warnf("handle: %v", err)
 				}
-			}(localTCP, sessRef, connRef, convRef)
+			}(localTCP, sessRef, convRef)
 		}
 
 		log.Warnf("session %08x closed, reconnecting", conv)

--- a/client/client.go
+++ b/client/client.go
@@ -30,13 +30,13 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-	utls "github.com/refraction-networking/utls"
-	"github.com/xtaci/kcp-go/v5"
-	"github.com/xtaci/smux"
 	"github.com/net2share/vaydns/dns"
 	"github.com/net2share/vaydns/noise"
 	"github.com/net2share/vaydns/turbotunnel"
+	utls "github.com/refraction-networking/utls"
+	log "github.com/sirupsen/logrus"
+	"github.com/xtaci/kcp-go/v5"
+	"github.com/xtaci/smux"
 )
 
 // Default timeouts for VayDNS mode.
@@ -47,10 +47,14 @@ const (
 	DefaultReconnectDelay       = 1 * time.Second
 	DefaultReconnectMaxDelay    = 30 * time.Second
 	DefaultSessionCheckInterval = 20 * time.Second
-	DefaultUDPResponseTimeout    = 500 * time.Millisecond
-	DefaultUDPWorkers            = 100
-	DefaultMaxStreams             = 256
-	DefaultHandshakeTimeout      = 15 * time.Second
+	DefaultUDPResponseTimeout   = 500 * time.Millisecond
+	DefaultUDPWorkers           = 100
+	DefaultMaxStreams           = 256
+	DefaultHandshakeTimeout     = 15 * time.Second
+)
+
+const (
+	DefaultPacketQueueSize = turbotunnel.DefaultQueueSize
 )
 
 // Default timeouts for dnstt compatibility mode.
@@ -197,11 +201,13 @@ type Tunnel struct {
 	IdleTimeout          time.Duration // default: 10s (2m with DnsttCompat)
 	KeepAlive            time.Duration // default: 2s (10s with DnsttCompat)
 	OpenStreamTimeout    time.Duration // default: 10s
-	MaxStreams            int           // default: 256 (0 = unlimited)
+	MaxStreams           int           // default: 256 (0 = unlimited)
 	ReconnectMinDelay    time.Duration // default: 1s
 	ReconnectMaxDelay    time.Duration // default: 30s
 	SessionCheckInterval time.Duration // default: 20s
 	HandshakeTimeout     time.Duration // default: 30s
+	PacketQueueSize      int           // default: 1024
+	KCPWindowSize        int           // default: PacketQueueSize/2
 
 	// internal state
 	wireConfig    turbotunnel.WireConfig
@@ -260,12 +266,40 @@ func (t *Tunnel) applyDefaults() {
 	if t.HandshakeTimeout == 0 {
 		t.HandshakeTimeout = DefaultHandshakeTimeout
 	}
+	if t.PacketQueueSize == 0 {
+		t.PacketQueueSize = DefaultPacketQueueSize
+	}
+	if t.KCPWindowSize == 0 {
+		t.KCPWindowSize = t.PacketQueueSize / 2
+		if t.KCPWindowSize < 1 {
+			t.KCPWindowSize = 1
+		}
+	}
+}
+
+func (t *Tunnel) effectivePacketQueueSize() int {
+	if t.PacketQueueSize > 0 {
+		return t.PacketQueueSize
+	}
+	return DefaultPacketQueueSize
+}
+
+func (t *Tunnel) effectiveKCPWindowSize() int {
+	if t.KCPWindowSize > 0 {
+		return t.KCPWindowSize
+	}
+	windowSize := t.effectivePacketQueueSize() / 2
+	if windowSize < 1 {
+		windowSize = 1
+	}
+	return windowSize
 }
 
 // InitiateResolverConnection creates the underlying transport connection
 // based on the Resolver configuration.
 func (t *Tunnel) InitiateResolverConnection() error {
 	r := t.Resolver
+	queueSize := t.effectivePacketQueueSize()
 	switch r.ResolverType {
 	case ResolverTypeUDP:
 		addr, err := net.ResolveUDPAddr("udp", r.ResolverAddr)
@@ -289,7 +323,7 @@ func (t *Tunnel) InitiateResolverConnection() error {
 			if timeout <= 0 {
 				timeout = DefaultUDPResponseTimeout
 			}
-			conn, forgedStats, err := NewUDPPacketConn(addr, r.DialerControl, workers, timeout, !r.UDPAcceptErrors)
+			conn, forgedStats, err := NewUDPPacketConnWithQueueSize(addr, r.DialerControl, workers, timeout, !r.UDPAcceptErrors, queueSize)
 			if err != nil {
 				return err
 			}
@@ -308,7 +342,7 @@ func (t *Tunnel) InitiateResolverConnection() error {
 		} else {
 			rt = http.DefaultTransport
 		}
-		conn, err := NewHTTPPacketConn(rt, r.ResolverAddr, 8)
+		conn, err := NewHTTPPacketConnWithQueueSize(rt, r.ResolverAddr, 8, queueSize)
 		if err != nil {
 			return err
 		}
@@ -328,7 +362,7 @@ func (t *Tunnel) InitiateResolverConnection() error {
 				return tls.DialWithDialer(&net.Dialer{}, network, addr, nil)
 			}
 		}
-		conn, err := NewTLSPacketConn(r.ResolverAddr, dialTLSContext)
+		conn, err := NewTLSPacketConnWithQueueSize(r.ResolverAddr, dialTLSContext, queueSize)
 		if err != nil {
 			return err
 		}
@@ -348,7 +382,7 @@ func (t *Tunnel) InitiateDNSPacketConn(domain dns.Name) error {
 	}
 	maxQnameLen := t.TunnelServer.effectiveMaxQnameLen()
 	rrType := t.TunnelServer.effectiveRRType()
-	t.dnsPacketConn = NewDNSPacketConn(t.resolverConn, t.remoteAddr, domain, rateLimiter, maxQnameLen, t.TunnelServer.MaxNumLabels, t.wireConfig, t.forgedStats, rrType)
+	t.dnsPacketConn = NewDNSPacketConnWithQueueSize(t.resolverConn, t.remoteAddr, domain, rateLimiter, maxQnameLen, t.TunnelServer.MaxNumLabels, t.wireConfig, t.forgedStats, rrType, t.effectivePacketQueueSize())
 	return nil
 }
 
@@ -373,7 +407,8 @@ func (t *Tunnel) InitiateKCPConn(mtu int) error {
 	log.Infof("session %08x ready", conn.GetConv())
 	conn.SetStreamMode(true)
 	conn.SetNoDelay(0, 0, 0, 1)
-	conn.SetWindowSize(turbotunnel.QueueSize/2, turbotunnel.QueueSize/2)
+	windowSize := t.effectiveKCPWindowSize()
+	conn.SetWindowSize(windowSize, windowSize)
 	if rc := conn.SetMtu(mtu); !rc {
 		conn.Close()
 		return fmt.Errorf("failed to set KCP MTU to %d", mtu)
@@ -425,39 +460,97 @@ func (t *Tunnel) InitiateSmuxSession() error {
 	return nil
 }
 
-// OpenStream opens a new multiplexed stream. Returns a net.Conn.
-func (t *Tunnel) OpenStream() (net.Conn, error) {
-	timeout := t.OpenStreamTimeout
-	if timeout <= 0 {
-		timeout = DefaultOpenStreamTimeout
-	}
-
+// openStreamWithTimeout waits for a new smux stream without taking any action
+// on timeout. The caller decides whether a timeout is a session-level failure
+// or just a failed connection attempt.
+func openStreamWithTimeout(conv uint32, timeout time.Duration, open func() (*smux.Stream, error)) (*smux.Stream, error) {
 	type result struct {
 		stream *smux.Stream
 		err    error
 	}
 	ch := make(chan result, 1)
 	go func() {
-		s, err := t.smuxSession.OpenStream()
+		s, err := open()
 		ch <- result{s, err}
 	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
 	select {
 	case r := <-ch:
 		if r.err != nil {
-			return nil, fmt.Errorf("session %08x opening stream: %v", t.kcpConn.GetConv(), r.err)
+			return nil, fmt.Errorf("session %08x opening stream: %v", conv, r.err)
 		}
-		log.Debugf("stream %08x:%d ready", t.kcpConn.GetConv(), r.stream.ID())
 		return r.stream, nil
-	case <-time.After(timeout):
+	case <-timer.C:
+		// If OpenStream eventually succeeds after the timeout, close the late
+		// stream so the caller does not accidentally leak capacity.
 		go func() {
-			r := <-ch
-			if r.stream != nil {
+			if r, ok := <-ch; ok && r.stream != nil {
 				r.stream.Close()
 			}
 		}()
-		return nil, fmt.Errorf("session %08x opening stream: timed out after %v", t.kcpConn.GetConv(), timeout)
+		return nil, fmt.Errorf("session %08x opening stream: timed out after %v", conv, timeout)
 	}
+}
+
+func shouldLogCopyError(err error) bool {
+	if err == nil || err == io.EOF || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, net.ErrClosed) {
+		return false
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return false
+	}
+	return true
+}
+
+func (t *Tunnel) closeTransportLayers() {
+	if t.dnsPacketConn != nil {
+		t.dnsPacketConn.Close()
+		t.dnsPacketConn = nil
+	}
+	if t.resolverConn != nil {
+		t.resolverConn.Close()
+		t.resolverConn = nil
+	}
+}
+
+func (t *Tunnel) resetTransportLayers() error {
+	t.closeTransportLayers()
+	if err := t.InitiateResolverConnection(); err != nil {
+		return err
+	}
+	if err := t.InitiateDNSPacketConn(t.TunnelServer.Addr); err != nil {
+		t.closeTransportLayers()
+		return err
+	}
+	return nil
+}
+
+// OpenStream opens a new multiplexed stream. Returns a net.Conn.
+func (t *Tunnel) OpenStream() (net.Conn, error) {
+	if t.smuxSession == nil {
+		return nil, fmt.Errorf("smux session is not initialized")
+	}
+
+	timeout := t.OpenStreamTimeout
+	if timeout <= 0 {
+		timeout = DefaultOpenStreamTimeout
+	}
+
+	var conv uint32
+	if t.kcpConn != nil {
+		conv = t.kcpConn.GetConv()
+	}
+
+	stream, err := openStreamWithTimeout(conv, timeout, t.smuxSession.OpenStream)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("stream %08x:%d ready", conv, stream.ID())
+	return stream, nil
 }
 
 // Handle forwards data between a local TCP connection and a tunnel stream.
@@ -473,10 +566,7 @@ func (t *Tunnel) Handle(lconn *net.TCPConn) error {
 	go func() {
 		defer wg.Done()
 		_, err := io.Copy(stream, lconn)
-		if err == io.EOF {
-			err = nil
-		}
-		if err != nil && !errors.Is(err, io.ErrClosedPipe) {
+		if shouldLogCopyError(err) {
 			log.Warnf("copy stream←local: %v", err)
 		}
 		lconn.CloseRead()
@@ -485,13 +575,11 @@ func (t *Tunnel) Handle(lconn *net.TCPConn) error {
 	go func() {
 		defer wg.Done()
 		_, err := io.Copy(lconn, stream)
-		if err == io.EOF {
-			err = nil
-		}
-		if err != nil && !errors.Is(err, io.ErrClosedPipe) {
+		if shouldLogCopyError(err) {
 			log.Warnf("copy local←stream: %v", err)
 		}
 		lconn.CloseWrite()
+		lconn.CloseRead()
 	}()
 	wg.Wait()
 
@@ -510,12 +598,10 @@ func (t *Tunnel) Close() error {
 		log.Debugf("session %08x closed", t.kcpConn.GetConv())
 		t.kcpConn.Close()
 	}
-	if t.dnsPacketConn != nil {
-		t.dnsPacketConn.Close()
-	}
-	if t.resolverConn != nil {
-		t.resolverConn.Close()
-	}
+	t.smuxSession = nil
+	t.noiseChannel = nil
+	t.kcpConn = nil
+	t.closeTransportLayers()
 	return nil
 }
 
@@ -538,22 +624,12 @@ func (t *Tunnel) ListenAndServe(listenAddr string) error {
 	}
 	log.Infof("effective MTU %d", mtu)
 
-	// Create the transport and DNS layer.
-	if err := t.InitiateResolverConnection(); err != nil {
-		return err
-	}
-	defer t.resolverConn.Close()
-
-	if err := t.InitiateDNSPacketConn(t.TunnelServer.Addr); err != nil {
-		return err
-	}
-	transportErrCh := t.dnsPacketConn.TransportErrors()
-
 	ln, err := net.ListenTCP("tcp", localAddr)
 	if err != nil {
 		return fmt.Errorf("opening local listener: %v", err)
 	}
 	defer ln.Close()
+	defer t.closeTransportLayers()
 
 	var sem chan struct{}
 	if t.MaxStreams > 0 {
@@ -564,13 +640,25 @@ func (t *Tunnel) ListenAndServe(listenAddr string) error {
 		// Create a new tunnel session with exponential backoff.
 		var conn *kcp.UDPSession
 		var sess *smux.Session
+		var transportErrCh <-chan error
 		delay := t.ReconnectMinDelay
 		for {
+			if err := t.resetTransportLayers(); err != nil {
+				log.Warnf("transport setup failed: %v; retrying in %v", err, delay)
+				time.Sleep(delay)
+				delay *= 2
+				if delay > t.ReconnectMaxDelay {
+					delay = t.ReconnectMaxDelay
+				}
+				continue
+			}
+			transportErrCh = t.dnsPacketConn.TransportErrors()
 			conn, sess, err = t.createSession(mtu)
 			if err == nil {
 				break
 			}
 			log.Warnf("session creation failed: %v; retrying in %v", err, delay)
+			t.closeTransportLayers()
 			time.Sleep(delay)
 			delay *= 2
 			if delay > t.ReconnectMaxDelay {
@@ -590,7 +678,10 @@ func (t *Tunnel) ListenAndServe(listenAddr string) error {
 					select {
 					case <-sessDone:
 						sessionAlive = false
-					case <-transportErrCh:
+					case transportErr := <-transportErrCh:
+						if transportErr != nil {
+							log.Warnf("session %08x transport error: %v", conv, transportErr)
+						}
 						sessionAlive = false
 					default:
 					}
@@ -598,6 +689,7 @@ func (t *Tunnel) ListenAndServe(listenAddr string) error {
 				}
 				sess.Close()
 				conn.Close()
+				t.closeTransportLayers()
 				return err
 			}
 
@@ -606,29 +698,37 @@ func (t *Tunnel) ListenAndServe(listenAddr string) error {
 				local.Close()
 				sessionAlive = false
 				continue
-			case <-transportErrCh:
+			case transportErr := <-transportErrCh:
+				if transportErr != nil {
+					log.Warnf("session %08x transport error: %v", conv, transportErr)
+				}
 				local.Close()
 				sessionAlive = false
 				continue
 			default:
 			}
 
-			go func() {
+			localTCP := local.(*net.TCPConn)
+			sessRef := sess
+			connRef := conn
+			convRef := conv
+			go func(local *net.TCPConn, sess *smux.Session, conn *kcp.UDPSession, conv uint32) {
 				if sem != nil {
 					sem <- struct{}{}
 					defer func() { <-sem }()
 				}
 				defer local.Close()
-				err := t.handleConn(local.(*net.TCPConn), sess, conv)
+				err := t.handleConn(local, sess, conv)
 				if err != nil {
 					log.Warnf("handle: %v", err)
 				}
-			}()
+			}(localTCP, sessRef, connRef, convRef)
 		}
 
 		log.Warnf("session %08x closed, reconnecting", conv)
 		sess.Close()
 		conn.Close()
+		t.closeTransportLayers()
 	}
 }
 
@@ -641,7 +741,8 @@ func (t *Tunnel) createSession(mtu int) (*kcp.UDPSession, *smux.Session, error) 
 	log.Infof("session %08x ready", conn.GetConv())
 	conn.SetStreamMode(true)
 	conn.SetNoDelay(0, 0, 0, 1)
-	conn.SetWindowSize(turbotunnel.QueueSize/2, turbotunnel.QueueSize/2)
+	windowSize := t.effectiveKCPWindowSize()
+	conn.SetWindowSize(windowSize, windowSize)
 	if rc := conn.SetMtu(mtu); !rc {
 		conn.Close()
 		return nil, nil, fmt.Errorf("failed to set KCP MTU to %d", mtu)
@@ -669,31 +770,9 @@ func (t *Tunnel) createSession(mtu int) (*kcp.UDPSession, *smux.Session, error) 
 
 // handleConn forwards a single TCP connection through the tunnel session.
 func (t *Tunnel) handleConn(local *net.TCPConn, sess *smux.Session, conv uint32) error {
-	type streamResult struct {
-		stream *smux.Stream
-		err    error
-	}
-	ch := make(chan streamResult, 1)
-	go func() {
-		s, err := sess.OpenStream()
-		ch <- streamResult{s, err}
-	}()
-
-	var stream *smux.Stream
-	select {
-	case r := <-ch:
-		if r.err != nil {
-			return fmt.Errorf("session %08x opening stream: %v", conv, r.err)
-		}
-		stream = r.stream
-	case <-time.After(t.OpenStreamTimeout):
-		go func() {
-			r := <-ch
-			if r.stream != nil {
-				r.stream.Close()
-			}
-		}()
-		return fmt.Errorf("session %08x opening stream: timed out after %v", conv, t.OpenStreamTimeout)
+	stream, err := openStreamWithTimeout(conv, t.OpenStreamTimeout, sess.OpenStream)
+	if err != nil {
+		return err
 	}
 
 	defer func() {
@@ -707,10 +786,7 @@ func (t *Tunnel) handleConn(local *net.TCPConn, sess *smux.Session, conv uint32)
 	go func() {
 		defer wg.Done()
 		_, err := io.Copy(stream, local)
-		if err == io.EOF {
-			err = nil
-		}
-		if err != nil && !errors.Is(err, io.ErrClosedPipe) {
+		if shouldLogCopyError(err) {
 			log.Warnf("stream %08x:%d copy stream←local: %v", conv, stream.ID(), err)
 		}
 		local.CloseRead()
@@ -719,13 +795,11 @@ func (t *Tunnel) handleConn(local *net.TCPConn, sess *smux.Session, conv uint32)
 	go func() {
 		defer wg.Done()
 		_, err := io.Copy(local, stream)
-		if err == io.EOF {
-			err = nil
-		}
-		if err != nil && !errors.Is(err, io.ErrClosedPipe) {
+		if shouldLogCopyError(err) {
 			log.Warnf("stream %08x:%d copy local←stream: %v", conv, stream.ID(), err)
 		}
 		local.CloseWrite()
+		local.CloseRead()
 	}()
 	wg.Wait()
 

--- a/client/dns.go
+++ b/client/dns.go
@@ -172,12 +172,20 @@ type DNSPacketConn struct {
 // forgedStats is shared with the transport layer (e.g. UDPPacketConn) for
 // consistent forged response tracking; if nil, a new instance is created.
 func NewDNSPacketConn(transport net.PacketConn, addr net.Addr, domain dns.Name, rateLimiter *RateLimiter, maxQnameLen int, maxNumLabels int, wireConfig turbotunnel.WireConfig, forgedStats *ForgedStats, rrType uint16) *DNSPacketConn {
-	return NewDNSPacketConnWithQueueSize(transport, addr, domain, rateLimiter, maxQnameLen, maxNumLabels, wireConfig, forgedStats, rrType, turbotunnel.DefaultQueueSize)
+	return NewDNSPacketConnWithQueueSize(transport, addr, domain, rateLimiter, maxQnameLen, maxNumLabels, wireConfig, forgedStats, rrType, turbotunnel.QueueSize)
 }
 
 // NewDNSPacketConnWithQueueSize is like NewDNSPacketConn but allows
 // configuring the packet queue size used between DNS and KCP layers.
 func NewDNSPacketConnWithQueueSize(transport net.PacketConn, addr net.Addr, domain dns.Name, rateLimiter *RateLimiter, maxQnameLen int, maxNumLabels int, wireConfig turbotunnel.WireConfig, forgedStats *ForgedStats, rrType uint16, queueSize int) *DNSPacketConn {
+	return NewDNSPacketConnWithQueueConfig(transport, addr, domain, rateLimiter, maxQnameLen, maxNumLabels, wireConfig, forgedStats, rrType, turbotunnel.QueuePacketConnConfig{
+		QueueSize: queueSize,
+	})
+}
+
+// NewDNSPacketConnWithQueueConfig is like NewDNSPacketConn but allows
+// configuring both queue size and overflow behavior.
+func NewDNSPacketConnWithQueueConfig(transport net.PacketConn, addr net.Addr, domain dns.Name, rateLimiter *RateLimiter, maxQnameLen int, maxNumLabels int, wireConfig turbotunnel.WireConfig, forgedStats *ForgedStats, rrType uint16, queueConfig turbotunnel.QueuePacketConnConfig) *DNSPacketConn {
 	if maxQnameLen <= 0 || maxQnameLen > 253 {
 		maxQnameLen = 253
 	}
@@ -200,7 +208,7 @@ func NewDNSPacketConnWithQueueSize(transport net.PacketConn, addr net.Addr, doma
 		maxNumLabels:    maxNumLabels,
 		forgedStats:     forgedStats,
 		transportErr:    make(chan error, 2),
-		QueuePacketConn: turbotunnel.NewQueuePacketConnWithSize(clientID, 0, queueSize),
+		QueuePacketConn: turbotunnel.NewQueuePacketConnWithConfig(clientID, 0, queueConfig),
 	}
 	go func() {
 		err := c.recvLoop(transport)

--- a/client/dns.go
+++ b/client/dns.go
@@ -172,6 +172,12 @@ type DNSPacketConn struct {
 // forgedStats is shared with the transport layer (e.g. UDPPacketConn) for
 // consistent forged response tracking; if nil, a new instance is created.
 func NewDNSPacketConn(transport net.PacketConn, addr net.Addr, domain dns.Name, rateLimiter *RateLimiter, maxQnameLen int, maxNumLabels int, wireConfig turbotunnel.WireConfig, forgedStats *ForgedStats, rrType uint16) *DNSPacketConn {
+	return NewDNSPacketConnWithQueueSize(transport, addr, domain, rateLimiter, maxQnameLen, maxNumLabels, wireConfig, forgedStats, rrType, turbotunnel.DefaultQueueSize)
+}
+
+// NewDNSPacketConnWithQueueSize is like NewDNSPacketConn but allows
+// configuring the packet queue size used between DNS and KCP layers.
+func NewDNSPacketConnWithQueueSize(transport net.PacketConn, addr net.Addr, domain dns.Name, rateLimiter *RateLimiter, maxQnameLen int, maxNumLabels int, wireConfig turbotunnel.WireConfig, forgedStats *ForgedStats, rrType uint16, queueSize int) *DNSPacketConn {
 	if maxQnameLen <= 0 || maxQnameLen > 253 {
 		maxQnameLen = 253
 	}
@@ -194,26 +200,36 @@ func NewDNSPacketConn(transport net.PacketConn, addr net.Addr, domain dns.Name, 
 		maxNumLabels:    maxNumLabels,
 		forgedStats:     forgedStats,
 		transportErr:    make(chan error, 2),
-		QueuePacketConn: turbotunnel.NewQueuePacketConn(clientID, 0),
+		QueuePacketConn: turbotunnel.NewQueuePacketConnWithSize(clientID, 0, queueSize),
 	}
 	go func() {
 		err := c.recvLoop(transport)
+		select {
+		case <-c.QueuePacketConn.Closed():
+			return
+		default:
+		}
 		if err != nil {
 			log.Errorf("recvLoop: %v", err)
-		}
-		select {
-		case c.transportErr <- fmt.Errorf("recvLoop: %w", err):
-		default:
+			select {
+			case c.transportErr <- fmt.Errorf("recvLoop: %w", err):
+			default:
+			}
 		}
 	}()
 	go func() {
 		err := c.sendLoop(transport, addr)
+		select {
+		case <-c.QueuePacketConn.Closed():
+			return
+		default:
+		}
 		if err != nil {
 			log.Errorf("sendLoop: %v", err)
-		}
-		select {
-		case c.transportErr <- fmt.Errorf("sendLoop: %w", err):
-		default:
+			select {
+			case c.transportErr <- fmt.Errorf("sendLoop: %w", err):
+			default:
+			}
 		}
 	}()
 	return c
@@ -523,16 +539,22 @@ func (c *DNSPacketConn) send(transport net.PacketConn, p []byte, addr net.Addr) 
 func (c *DNSPacketConn) sendLoop(transport net.PacketConn, addr net.Addr) error {
 	pollDelay := initPollDelay
 	pollTimer := time.NewTimer(pollDelay)
+	defer pollTimer.Stop()
+	outgoing := c.QueuePacketConn.OutgoingQueue(addr)
+	closed := c.QueuePacketConn.Closed()
 	for {
 		var p []byte
-		outgoing := c.QueuePacketConn.OutgoingQueue(addr)
 		pollTimerExpired := false
 		// Prioritize sending an actual data packet from outgoing. Only
 		// consider a poll when outgoing is empty.
 		select {
+		case <-closed:
+			return nil
 		case p = <-outgoing:
 		default:
 			select {
+			case <-closed:
+				return nil
 			case p = <-outgoing:
 			case <-c.pollChan:
 			case <-pollTimer.C:
@@ -571,10 +593,18 @@ func (c *DNSPacketConn) sendLoop(transport net.PacketConn, addr net.Addr) error 
 		// the data capacity of queries is so limited, it's not worth
 		// trying to send more than one packet per query.
 		c.rateLimiter.Wait()
+		select {
+		case <-closed:
+			return nil
+		default:
+		}
 		err := c.send(transport, p, addr)
 		if err != nil {
-			log.Errorf("send: %v", err)
-			continue
+			if err, ok := err.(net.Error); ok && err.Temporary() {
+				log.Warnf("send temporary error: %v", err)
+				continue
+			}
+			return err
 		}
 	}
 }

--- a/client/http.go
+++ b/client/http.go
@@ -59,13 +59,19 @@ type HTTPPacketConn struct {
 // path components; e.g., "/dns-query". numSenders is the number of concurrent
 // sender-receiver goroutines to run.
 func NewHTTPPacketConn(rt http.RoundTripper, urlString string, numSenders int) (*HTTPPacketConn, error) {
+	return NewHTTPPacketConnWithQueueSize(rt, urlString, numSenders, turbotunnel.DefaultQueueSize)
+}
+
+// NewHTTPPacketConnWithQueueSize is like NewHTTPPacketConn but allows
+// configuring the transport queue size.
+func NewHTTPPacketConnWithQueueSize(rt http.RoundTripper, urlString string, numSenders int, queueSize int) (*HTTPPacketConn, error) {
 	c := &HTTPPacketConn{
 		client: &http.Client{
 			Transport: rt,
 			Timeout:   1 * time.Minute,
 		},
 		urlString:       urlString,
-		QueuePacketConn: turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, 0),
+		QueuePacketConn: turbotunnel.NewQueuePacketConnWithSize(turbotunnel.DummyAddr{}, 0, queueSize),
 	}
 	for i := 0; i < numSenders; i++ {
 		go c.sendLoop()

--- a/client/http.go
+++ b/client/http.go
@@ -59,19 +59,27 @@ type HTTPPacketConn struct {
 // path components; e.g., "/dns-query". numSenders is the number of concurrent
 // sender-receiver goroutines to run.
 func NewHTTPPacketConn(rt http.RoundTripper, urlString string, numSenders int) (*HTTPPacketConn, error) {
-	return NewHTTPPacketConnWithQueueSize(rt, urlString, numSenders, turbotunnel.DefaultQueueSize)
+	return NewHTTPPacketConnWithQueueSize(rt, urlString, numSenders, turbotunnel.QueueSize)
 }
 
 // NewHTTPPacketConnWithQueueSize is like NewHTTPPacketConn but allows
 // configuring the transport queue size.
 func NewHTTPPacketConnWithQueueSize(rt http.RoundTripper, urlString string, numSenders int, queueSize int) (*HTTPPacketConn, error) {
+	return NewHTTPPacketConnWithQueueConfig(rt, urlString, numSenders, turbotunnel.QueuePacketConnConfig{
+		QueueSize: queueSize,
+	})
+}
+
+// NewHTTPPacketConnWithQueueConfig is like NewHTTPPacketConn but allows
+// configuring both queue size and overflow behavior.
+func NewHTTPPacketConnWithQueueConfig(rt http.RoundTripper, urlString string, numSenders int, queueConfig turbotunnel.QueuePacketConnConfig) (*HTTPPacketConn, error) {
 	c := &HTTPPacketConn{
 		client: &http.Client{
 			Transport: rt,
 			Timeout:   1 * time.Minute,
 		},
 		urlString:       urlString,
-		QueuePacketConn: turbotunnel.NewQueuePacketConnWithSize(turbotunnel.DummyAddr{}, 0, queueSize),
+		QueuePacketConn: turbotunnel.NewQueuePacketConnWithConfig(turbotunnel.DummyAddr{}, 0, queueConfig),
 	}
 	for i := 0; i < numSenders; i++ {
 		go c.sendLoop()
@@ -147,7 +155,15 @@ func (c *HTTPPacketConn) send(p []byte) error {
 // sendLoop loops over the contents of the outgoing queue and passes them to
 // send. It drops packets while c.notBefore is in the future.
 func (c *HTTPPacketConn) sendLoop() {
-	for p := range c.QueuePacketConn.OutgoingQueue(turbotunnel.DummyAddr{}) {
+	outgoing := c.QueuePacketConn.OutgoingQueue(turbotunnel.DummyAddr{})
+	closed := c.QueuePacketConn.Closed()
+	for {
+		var p []byte
+		select {
+		case <-closed:
+			return
+		case p = <-outgoing:
+		}
 		// Stop sending while we are rate-limiting ourselves (as a
 		// result of a Retry-After response header, for example).
 		c.notBeforeLock.RLock()

--- a/client/tls.go
+++ b/client/tls.go
@@ -37,6 +37,12 @@ type TLSPacketConn struct {
 // the resolver, reconnecting as necessary. It closes the connection if any
 // reconnection attempt fails.
 func NewTLSPacketConn(addr string, dialTLSContext func(ctx context.Context, network, addr string) (net.Conn, error)) (*TLSPacketConn, error) {
+	return NewTLSPacketConnWithQueueSize(addr, dialTLSContext, turbotunnel.DefaultQueueSize)
+}
+
+// NewTLSPacketConnWithQueueSize is like NewTLSPacketConn but allows
+// configuring the transport queue size.
+func NewTLSPacketConnWithQueueSize(addr string, dialTLSContext func(ctx context.Context, network, addr string) (net.Conn, error), queueSize int) (*TLSPacketConn, error) {
 	dial := func() (net.Conn, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
 		defer cancel()
@@ -51,7 +57,7 @@ func NewTLSPacketConn(addr string, dialTLSContext func(ctx context.Context, netw
 		return nil, err
 	}
 	c := &TLSPacketConn{
-		QueuePacketConn: turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, 0),
+		QueuePacketConn: turbotunnel.NewQueuePacketConnWithSize(turbotunnel.DummyAddr{}, 0, queueSize),
 	}
 	go func() {
 		defer c.Close()

--- a/client/tls.go
+++ b/client/tls.go
@@ -30,6 +30,8 @@ type TLSPacketConn struct {
 	// recvLoop and sendLoop take the messages out of the receive and send
 	// queues and actually put them on the network.
 	*turbotunnel.QueuePacketConn
+	connMu sync.Mutex
+	conn   net.Conn
 }
 
 // NewTLSPacketConn creates a new TLSPacketConn configured to use the TLS
@@ -37,12 +39,20 @@ type TLSPacketConn struct {
 // the resolver, reconnecting as necessary. It closes the connection if any
 // reconnection attempt fails.
 func NewTLSPacketConn(addr string, dialTLSContext func(ctx context.Context, network, addr string) (net.Conn, error)) (*TLSPacketConn, error) {
-	return NewTLSPacketConnWithQueueSize(addr, dialTLSContext, turbotunnel.DefaultQueueSize)
+	return NewTLSPacketConnWithQueueSize(addr, dialTLSContext, turbotunnel.QueueSize)
 }
 
 // NewTLSPacketConnWithQueueSize is like NewTLSPacketConn but allows
 // configuring the transport queue size.
 func NewTLSPacketConnWithQueueSize(addr string, dialTLSContext func(ctx context.Context, network, addr string) (net.Conn, error), queueSize int) (*TLSPacketConn, error) {
+	return NewTLSPacketConnWithQueueConfig(addr, dialTLSContext, turbotunnel.QueuePacketConnConfig{
+		QueueSize: queueSize,
+	})
+}
+
+// NewTLSPacketConnWithQueueConfig is like NewTLSPacketConn but allows
+// configuring both queue size and overflow behavior.
+func NewTLSPacketConnWithQueueConfig(addr string, dialTLSContext func(ctx context.Context, network, addr string) (net.Conn, error), queueConfig turbotunnel.QueuePacketConnConfig) (*TLSPacketConn, error) {
 	dial := func() (net.Conn, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
 		defer cancel()
@@ -57,8 +67,9 @@ func NewTLSPacketConnWithQueueSize(addr string, dialTLSContext func(ctx context.
 		return nil, err
 	}
 	c := &TLSPacketConn{
-		QueuePacketConn: turbotunnel.NewQueuePacketConnWithSize(turbotunnel.DummyAddr{}, 0, queueSize),
+		QueuePacketConn: turbotunnel.NewQueuePacketConnWithConfig(turbotunnel.DummyAddr{}, 0, queueConfig),
 	}
+	c.setConn(conn)
 	go func() {
 		defer c.Close()
 		for {
@@ -79,7 +90,13 @@ func NewTLSPacketConnWithQueueSize(addr string, dialTLSContext func(ctx context.
 				wg.Done()
 			}()
 			wg.Wait()
+			c.clearConn(conn)
 			conn.Close()
+			select {
+			case <-c.Closed():
+				return
+			default:
+			}
 
 			// Whenever the TLS connection dies, redial a new one.
 			conn, err = dial()
@@ -87,9 +104,46 @@ func NewTLSPacketConnWithQueueSize(addr string, dialTLSContext func(ctx context.
 				log.Errorf("dial tls: %v", err)
 				break
 			}
+			select {
+			case <-c.Closed():
+				conn.Close()
+				return
+			default:
+			}
+			c.setConn(conn)
 		}
 	}()
 	return c, nil
+}
+
+func (c *TLSPacketConn) setConn(conn net.Conn) {
+	c.connMu.Lock()
+	c.conn = conn
+	c.connMu.Unlock()
+}
+
+func (c *TLSPacketConn) clearConn(conn net.Conn) {
+	c.connMu.Lock()
+	if c.conn == conn {
+		c.conn = nil
+	}
+	c.connMu.Unlock()
+}
+
+func (c *TLSPacketConn) closeCurrentConn() {
+	c.connMu.Lock()
+	conn := c.conn
+	c.conn = nil
+	c.connMu.Unlock()
+	if conn != nil {
+		conn.Close()
+	}
+}
+
+// Close tears down both the packet queue and any active TLS connection.
+func (c *TLSPacketConn) Close() error {
+	c.closeCurrentConn()
+	return c.QueuePacketConn.Close()
 }
 
 // recvLoop reads length-prefixed messages from conn and passes them to the
@@ -118,7 +172,15 @@ func (c *TLSPacketConn) recvLoop(conn net.Conn) error {
 // length-prefixed, to conn.
 func (c *TLSPacketConn) sendLoop(conn net.Conn) error {
 	bw := bufio.NewWriter(conn)
-	for p := range c.QueuePacketConn.OutgoingQueue(turbotunnel.DummyAddr{}) {
+	outgoing := c.QueuePacketConn.OutgoingQueue(turbotunnel.DummyAddr{})
+	closed := c.QueuePacketConn.Closed()
+	for {
+		var p []byte
+		select {
+		case <-closed:
+			return nil
+		case p = <-outgoing:
+		}
 		length := uint16(len(p))
 		if int(length) != len(p) {
 			panic(len(p))
@@ -136,5 +198,4 @@ func (c *TLSPacketConn) sendLoop(conn net.Conn) error {
 			return err
 		}
 	}
-	return nil
 }

--- a/client/udp.go
+++ b/client/udp.go
@@ -37,6 +37,12 @@ type UDPPacketConn struct {
 // ForgedStats pointer is shared with the caller so DNSPacketConn can
 // include per-query forged counts in its reporting.
 func NewUDPPacketConn(remoteAddr net.Addr, dialerControl func(network, address string, c syscall.RawConn) error, numWorkers int, responseTimeout time.Duration, ignoreErrors bool) (*UDPPacketConn, *ForgedStats, error) {
+	return NewUDPPacketConnWithQueueSize(remoteAddr, dialerControl, numWorkers, responseTimeout, ignoreErrors, turbotunnel.DefaultQueueSize)
+}
+
+// NewUDPPacketConnWithQueueSize is like NewUDPPacketConn but allows
+// configuring the transport queue size.
+func NewUDPPacketConnWithQueueSize(remoteAddr net.Addr, dialerControl func(network, address string, c syscall.RawConn) error, numWorkers int, responseTimeout time.Duration, ignoreErrors bool, queueSize int) (*UDPPacketConn, *ForgedStats, error) {
 	stats := &ForgedStats{}
 	pconn := &UDPPacketConn{
 		remoteAddr:      remoteAddr,
@@ -44,7 +50,7 @@ func NewUDPPacketConn(remoteAddr net.Addr, dialerControl func(network, address s
 		responseTimeout: responseTimeout,
 		ignoreErrors:    ignoreErrors,
 		forgedStats:     stats,
-		QueuePacketConn: turbotunnel.NewQueuePacketConn(remoteAddr, 0),
+		QueuePacketConn: turbotunnel.NewQueuePacketConnWithSize(remoteAddr, 0, queueSize),
 	}
 	for i := 0; i < numWorkers; i++ {
 		go pconn.sendLoop()
@@ -63,10 +69,24 @@ func (c *UDPPacketConn) sendLoop() {
 		maxBackoff  = 5 * time.Second
 	)
 	backoff := initBackoff
+	outgoing := c.OutgoingQueue(c.remoteAddr)
+	closed := c.Closed()
 
-	for p := range c.OutgoingQueue(c.remoteAddr) {
+	for {
+		var p []byte
+		select {
+		case <-closed:
+			return
+		case p = <-outgoing:
+		}
 		if err := c.sendRecv(p); err != nil {
-			time.Sleep(backoff)
+			timer := time.NewTimer(backoff)
+			select {
+			case <-closed:
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
 			backoff *= 2
 			if backoff > maxBackoff {
 				backoff = maxBackoff

--- a/client/udp.go
+++ b/client/udp.go
@@ -37,12 +37,20 @@ type UDPPacketConn struct {
 // ForgedStats pointer is shared with the caller so DNSPacketConn can
 // include per-query forged counts in its reporting.
 func NewUDPPacketConn(remoteAddr net.Addr, dialerControl func(network, address string, c syscall.RawConn) error, numWorkers int, responseTimeout time.Duration, ignoreErrors bool) (*UDPPacketConn, *ForgedStats, error) {
-	return NewUDPPacketConnWithQueueSize(remoteAddr, dialerControl, numWorkers, responseTimeout, ignoreErrors, turbotunnel.DefaultQueueSize)
+	return NewUDPPacketConnWithQueueSize(remoteAddr, dialerControl, numWorkers, responseTimeout, ignoreErrors, turbotunnel.QueueSize)
 }
 
 // NewUDPPacketConnWithQueueSize is like NewUDPPacketConn but allows
 // configuring the transport queue size.
 func NewUDPPacketConnWithQueueSize(remoteAddr net.Addr, dialerControl func(network, address string, c syscall.RawConn) error, numWorkers int, responseTimeout time.Duration, ignoreErrors bool, queueSize int) (*UDPPacketConn, *ForgedStats, error) {
+	return NewUDPPacketConnWithQueueConfig(remoteAddr, dialerControl, numWorkers, responseTimeout, ignoreErrors, turbotunnel.QueuePacketConnConfig{
+		QueueSize: queueSize,
+	})
+}
+
+// NewUDPPacketConnWithQueueConfig is like NewUDPPacketConn but allows
+// configuring both queue size and overflow behavior.
+func NewUDPPacketConnWithQueueConfig(remoteAddr net.Addr, dialerControl func(network, address string, c syscall.RawConn) error, numWorkers int, responseTimeout time.Duration, ignoreErrors bool, queueConfig turbotunnel.QueuePacketConnConfig) (*UDPPacketConn, *ForgedStats, error) {
 	stats := &ForgedStats{}
 	pconn := &UDPPacketConn{
 		remoteAddr:      remoteAddr,
@@ -50,7 +58,7 @@ func NewUDPPacketConnWithQueueSize(remoteAddr net.Addr, dialerControl func(netwo
 		responseTimeout: responseTimeout,
 		ignoreErrors:    ignoreErrors,
 		forgedStats:     stats,
-		QueuePacketConn: turbotunnel.NewQueuePacketConnWithSize(remoteAddr, 0, queueSize),
+		QueuePacketConn: turbotunnel.NewQueuePacketConnWithConfig(remoteAddr, 0, queueConfig),
 	}
 	for i := 0; i < numWorkers; i++ {
 		go pconn.sendLoop()

--- a/turbotunnel/consts.go
+++ b/turbotunnel/consts.go
@@ -4,14 +4,46 @@
 // https://github.com/net4people/bbs/issues/9
 package turbotunnel
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
 
 // DefaultQueueSize is the default size of send and receive queues in
 // QueuePacketConn and RemoteMap.
 const DefaultQueueSize = 1024
 
-// QueueSize is kept as an alias for the default queue size.
-const QueueSize = DefaultQueueSize
+// QueueSize is kept for backward compatibility with older code that relied on
+// the historical fixed queue size.
+const QueueSize = 128
+
+// QueueOverflowMode controls how QueuePacketConn behaves when its queues are
+// full.
+type QueueOverflowMode string
+
+const (
+	// QueueOverflowDrop preserves the original dnstt/vaydns behavior: packets
+	// are dropped when local queues are full and KCP handles retransmission.
+	QueueOverflowDrop QueueOverflowMode = "drop"
+	// QueueOverflowBlock applies backpressure by blocking writers until queue
+	// space is available or the queue is closed.
+	QueueOverflowBlock QueueOverflowMode = "block"
+
+	DefaultQueueOverflowMode = QueueOverflowDrop
+)
+
+// ParseQueueOverflowMode validates a queue overflow mode string.
+func ParseQueueOverflowMode(s string) (QueueOverflowMode, error) {
+	switch mode := QueueOverflowMode(strings.ToLower(s)); mode {
+	case "":
+		return DefaultQueueOverflowMode, nil
+	case QueueOverflowDrop, QueueOverflowBlock:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("invalid queue overflow mode %q (want drop or block)", s)
+	}
+}
 
 var errClosedPacketConn = errors.New("operation on closed connection")
 var errNotImplemented = errors.New("not implemented")

--- a/turbotunnel/consts.go
+++ b/turbotunnel/consts.go
@@ -6,9 +6,12 @@ package turbotunnel
 
 import "errors"
 
-// QueueSize is the size of send and receive queues in QueuePacketConn and
-// RemoteMap.
-const QueueSize = 128
+// DefaultQueueSize is the default size of send and receive queues in
+// QueuePacketConn and RemoteMap.
+const DefaultQueueSize = 1024
+
+// QueueSize is kept as an alias for the default queue size.
+const QueueSize = DefaultQueueSize
 
 var errClosedPacketConn = errors.New("operation on closed connection")
 var errNotImplemented = errors.New("not implemented")

--- a/turbotunnel/queuepacketconn.go
+++ b/turbotunnel/queuepacketconn.go
@@ -45,10 +45,19 @@ type QueuePacketConn struct {
 // NewQueuePacketConn makes a new QueuePacketConn, set to track recent peers
 // for at least a duration of timeout.
 func NewQueuePacketConn(localAddr net.Addr, timeout time.Duration) *QueuePacketConn {
+	return NewQueuePacketConnWithSize(localAddr, timeout, DefaultQueueSize)
+}
+
+// NewQueuePacketConnWithSize makes a new QueuePacketConn with a specific queue
+// size, set to track recent peers for at least a duration of timeout.
+func NewQueuePacketConnWithSize(localAddr net.Addr, timeout time.Duration, queueSize int) *QueuePacketConn {
+	if queueSize <= 0 {
+		queueSize = DefaultQueueSize
+	}
 	return &QueuePacketConn{
-		remotes:   NewRemoteMap(timeout),
+		remotes:   NewRemoteMap(timeout, queueSize),
 		localAddr: localAddr,
-		recvQueue: make(chan taggedPacket, QueueSize),
+		recvQueue: make(chan taggedPacket, queueSize),
 		closed:    make(chan struct{}),
 	}
 }
@@ -66,9 +75,9 @@ func (c *QueuePacketConn) QueueIncoming(p []byte, addr net.Addr) {
 	buf := make([]byte, len(p))
 	copy(buf, p)
 	select {
+	case <-c.closed:
+		return
 	case c.recvQueue <- taggedPacket{buf, addr}:
-	default:
-		// Drop the incoming packet if the receive queue is full.
 	}
 }
 
@@ -119,12 +128,17 @@ func (c *QueuePacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
 	// Copy the slice so that the caller may reuse it.
 	buf := make([]byte, len(p))
 	copy(buf, p)
-	select {
-	case c.remotes.SendQueue(addr) <- buf:
-		return len(buf), nil
-	default:
-		// Drop the outgoing packet if the send queue is full.
-		return len(buf), nil
+	for {
+		record := c.remotes.lookup(addr)
+		select {
+		case <-c.closed:
+			return 0, &net.OpError{Op: "write", Net: c.LocalAddr().Network(), Addr: c.LocalAddr(), Err: c.err.Load().(error)}
+		case <-record.Closed:
+			// Retry on a fresh queue if this remote expired while we were waiting.
+			continue
+		case record.SendQueue <- buf:
+			return len(buf), nil
+		}
 	}
 }
 
@@ -153,6 +167,9 @@ func (c *QueuePacketConn) closeWithError(err error) error {
 func (c *QueuePacketConn) Close() error {
 	return c.closeWithError(nil)
 }
+
+// Closed returns a channel that is closed when the QueuePacketConn is closed.
+func (c *QueuePacketConn) Closed() <-chan struct{} { return c.closed }
 
 // LocalAddr returns the localAddr value that was passed to NewQueuePacketConn.
 func (c *QueuePacketConn) LocalAddr() net.Addr { return c.localAddr }

--- a/turbotunnel/queuepacketconn.go
+++ b/turbotunnel/queuepacketconn.go
@@ -33,32 +33,67 @@ type taggedPacket struct {
 // packet has been stashed, it must be checked for by calling Unstash in
 // addition to OutgoingQueue.
 type QueuePacketConn struct {
-	remotes   *RemoteMap
-	localAddr net.Addr
-	recvQueue chan taggedPacket
-	closeOnce sync.Once
-	closed    chan struct{}
+	remotes      *RemoteMap
+	localAddr    net.Addr
+	recvQueue    chan taggedPacket
+	overflowMode QueueOverflowMode
+	closeOnce    sync.Once
+	closed       chan struct{}
 	// What error to return when the QueuePacketConn is closed.
 	err atomic.Value
+}
+
+type writeOutgoingResult int
+
+const (
+	writeOutgoingDropped writeOutgoingResult = iota
+	writeOutgoingSent
+	writeOutgoingRetry
+	writeOutgoingConnClosed
+)
+
+// QueuePacketConnConfig controls QueuePacketConn sizing and overflow behavior.
+type QueuePacketConnConfig struct {
+	QueueSize    int
+	OverflowMode QueueOverflowMode
+}
+
+func (cfg QueuePacketConnConfig) withDefaults() QueuePacketConnConfig {
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = DefaultQueueSize
+	}
+	// Keep low-level config permissive for backward compatibility: empty or
+	// unknown overflow modes fall back to the original lossy behavior.
+	if cfg.OverflowMode != QueueOverflowBlock {
+		cfg.OverflowMode = DefaultQueueOverflowMode
+	}
+	return cfg
 }
 
 // NewQueuePacketConn makes a new QueuePacketConn, set to track recent peers
 // for at least a duration of timeout.
 func NewQueuePacketConn(localAddr net.Addr, timeout time.Duration) *QueuePacketConn {
-	return NewQueuePacketConnWithSize(localAddr, timeout, DefaultQueueSize)
+	return NewQueuePacketConnWithSize(localAddr, timeout, QueueSize)
 }
 
 // NewQueuePacketConnWithSize makes a new QueuePacketConn with a specific queue
 // size, set to track recent peers for at least a duration of timeout.
 func NewQueuePacketConnWithSize(localAddr net.Addr, timeout time.Duration, queueSize int) *QueuePacketConn {
-	if queueSize <= 0 {
-		queueSize = DefaultQueueSize
-	}
+	return NewQueuePacketConnWithConfig(localAddr, timeout, QueuePacketConnConfig{
+		QueueSize: queueSize,
+	})
+}
+
+// NewQueuePacketConnWithConfig makes a new QueuePacketConn with the given queue
+// configuration, set to track recent peers for at least a duration of timeout.
+func NewQueuePacketConnWithConfig(localAddr net.Addr, timeout time.Duration, cfg QueuePacketConnConfig) *QueuePacketConn {
+	cfg = cfg.withDefaults()
 	return &QueuePacketConn{
-		remotes:   NewRemoteMap(timeout, queueSize),
-		localAddr: localAddr,
-		recvQueue: make(chan taggedPacket, queueSize),
-		closed:    make(chan struct{}),
+		remotes:      NewRemoteMap(timeout, cfg.QueueSize),
+		localAddr:    localAddr,
+		recvQueue:    make(chan taggedPacket, cfg.QueueSize),
+		overflowMode: cfg.OverflowMode,
+		closed:       make(chan struct{}),
 	}
 }
 
@@ -74,10 +109,20 @@ func (c *QueuePacketConn) QueueIncoming(p []byte, addr net.Addr) {
 	// Copy the slice so that the caller may reuse it.
 	buf := make([]byte, len(p))
 	copy(buf, p)
+	if c.overflowMode == QueueOverflowBlock {
+		select {
+		case <-c.closed:
+			return
+		case c.recvQueue <- taggedPacket{buf, addr}:
+		}
+		return
+	}
 	select {
 	case <-c.closed:
 		return
 	case c.recvQueue <- taggedPacket{buf, addr}:
+	default:
+		// Drop the incoming packet if the receive queue is full.
 	}
 }
 
@@ -130,15 +175,45 @@ func (c *QueuePacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
 	copy(buf, p)
 	for {
 		record := c.remotes.lookup(addr)
-		select {
-		case <-c.closed:
+		switch c.writeOutgoing(record, buf) {
+		case writeOutgoingConnClosed:
 			return 0, &net.OpError{Op: "write", Net: c.LocalAddr().Network(), Addr: c.LocalAddr(), Err: c.err.Load().(error)}
-		case <-record.Closed:
-			// Retry on a fresh queue if this remote expired while we were waiting.
+		case writeOutgoingRetry:
+			// The remote queue expired while we were selecting, so look up a fresh
+			// queue and try again.
 			continue
-		case record.SendQueue <- buf:
+		case writeOutgoingSent:
+			return len(buf), nil
+		case writeOutgoingDropped:
+			// Drop the outgoing packet if the send queue is full.
 			return len(buf), nil
 		}
+	}
+}
+
+// writeOutgoing writes buf to record.SendQueue according to the configured
+// overflow mode.
+func (c *QueuePacketConn) writeOutgoing(record *remoteRecord, buf []byte) writeOutgoingResult {
+	record.sendMu.Lock()
+	defer record.sendMu.Unlock()
+	if record.expired {
+		return writeOutgoingRetry
+	}
+	if c.overflowMode == QueueOverflowBlock {
+		select {
+		case <-c.closed:
+			return writeOutgoingConnClosed
+		case record.SendQueue <- buf:
+			return writeOutgoingSent
+		}
+	}
+	select {
+	case <-c.closed:
+		return writeOutgoingConnClosed
+	case record.SendQueue <- buf:
+		return writeOutgoingSent
+	default:
+		return writeOutgoingDropped
 	}
 }
 

--- a/turbotunnel/remotemap.go
+++ b/turbotunnel/remotemap.go
@@ -14,6 +14,7 @@ type remoteRecord struct {
 	LastSeen  time.Time
 	SendQueue chan []byte
 	Stash     chan []byte
+	Closed    chan struct{}
 }
 
 // RemoteMap manages a mapping of live remote peers, keyed by address, to their
@@ -30,6 +31,8 @@ type RemoteMap struct {
 	inner remoteMapInner
 	// Synchronizes access to inner.
 	lock sync.Mutex
+	// queueSize is the bounded capacity for each remote send queue.
+	queueSize int
 }
 
 // NewRemoteMap creates a RemoteMap that expires peers after a timeout.
@@ -42,12 +45,16 @@ type RemoteMap struct {
 // time. If smux later decides to send more packets to the same peer, we'll
 // instantiate a new send queue, and if the peer is ever seen again with a
 // matching address, we'll deliver them.
-func NewRemoteMap(timeout time.Duration) *RemoteMap {
+func NewRemoteMap(timeout time.Duration, queueSize int) *RemoteMap {
+	if queueSize <= 0 {
+		queueSize = DefaultQueueSize
+	}
 	m := &RemoteMap{
 		inner: remoteMapInner{
 			byAge:  make([]*remoteRecord, 0),
 			byAddr: make(map[net.Addr]int),
 		},
+		queueSize: queueSize,
 	}
 	if timeout > 0 {
 		go func() {
@@ -68,7 +75,15 @@ func NewRemoteMap(timeout time.Duration) *RemoteMap {
 func (m *RemoteMap) SendQueue(addr net.Addr) chan []byte {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return m.inner.Lookup(addr, time.Now()).SendQueue
+	return m.inner.Lookup(addr, time.Now(), m.queueSize).SendQueue
+}
+
+// lookup returns the remote record corresponding to addr, creating it if
+// necessary.
+func (m *RemoteMap) lookup(addr net.Addr) *remoteRecord {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.inner.Lookup(addr, time.Now(), m.queueSize)
 }
 
 // Stash places p in the stash corresponding to addr, if the stash is not
@@ -78,7 +93,7 @@ func (m *RemoteMap) Stash(addr net.Addr, p []byte) bool {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	select {
-	case m.inner.Lookup(addr, time.Now()).Stash <- p:
+	case m.inner.Lookup(addr, time.Now(), m.queueSize).Stash <- p:
 		return true
 	default:
 		return false
@@ -89,7 +104,7 @@ func (m *RemoteMap) Stash(addr net.Addr, p []byte) bool {
 func (m *RemoteMap) Unstash(addr net.Addr) <-chan []byte {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return m.inner.Lookup(addr, time.Now()).Stash
+	return m.inner.Lookup(addr, time.Now(), m.queueSize).Stash
 }
 
 // remoteMapInner is the inner type of RemoteMap, implementing heap.Interface.
@@ -107,14 +122,14 @@ type remoteMapInner struct {
 func (inner *remoteMapInner) removeExpired(now time.Time, timeout time.Duration) {
 	for len(inner.byAge) > 0 && now.Sub(inner.byAge[0].LastSeen) >= timeout {
 		record := heap.Pop(inner).(*remoteRecord)
-		close(record.SendQueue)
+		close(record.Closed)
 	}
 }
 
 // Lookup finds the existing record corresponding to addr, or creates a new
 // one if none exists yet. It updates the record's LastSeen time and returns the
 // record.
-func (inner *remoteMapInner) Lookup(addr net.Addr, now time.Time) *remoteRecord {
+func (inner *remoteMapInner) Lookup(addr net.Addr, now time.Time, queueSize int) *remoteRecord {
 	var record *remoteRecord
 	i, ok := inner.byAddr[addr]
 	if ok {
@@ -127,8 +142,9 @@ func (inner *remoteMapInner) Lookup(addr net.Addr, now time.Time) *remoteRecord 
 		record = &remoteRecord{
 			Addr:      addr,
 			LastSeen:  now,
-			SendQueue: make(chan []byte, QueueSize),
+			SendQueue: make(chan []byte, queueSize),
 			Stash:     make(chan []byte, 1),
+			Closed:    make(chan struct{}),
 		}
 		heap.Push(inner, record)
 	}

--- a/turbotunnel/remotemap.go
+++ b/turbotunnel/remotemap.go
@@ -14,7 +14,8 @@ type remoteRecord struct {
 	LastSeen  time.Time
 	SendQueue chan []byte
 	Stash     chan []byte
-	Closed    chan struct{}
+	sendMu    sync.Mutex
+	expired   bool
 }
 
 // RemoteMap manages a mapping of live remote peers, keyed by address, to their
@@ -45,16 +46,24 @@ type RemoteMap struct {
 // time. If smux later decides to send more packets to the same peer, we'll
 // instantiate a new send queue, and if the peer is ever seen again with a
 // matching address, we'll deliver them.
-func NewRemoteMap(timeout time.Duration, queueSize int) *RemoteMap {
-	if queueSize <= 0 {
-		queueSize = DefaultQueueSize
+//
+// queueSize is optional for backward compatibility; when omitted, the historical
+// QueueSize default is used. When explicitly provided as non-positive,
+// DefaultQueueSize is used.
+func NewRemoteMap(timeout time.Duration, queueSize ...int) *RemoteMap {
+	size := QueueSize
+	if len(queueSize) > 0 {
+		size = queueSize[0]
+		if size <= 0 {
+			size = DefaultQueueSize
+		}
 	}
 	m := &RemoteMap{
 		inner: remoteMapInner{
 			byAge:  make([]*remoteRecord, 0),
 			byAddr: make(map[net.Addr]int),
 		},
-		queueSize: queueSize,
+		queueSize: size,
 	}
 	if timeout > 0 {
 		go func() {
@@ -122,7 +131,10 @@ type remoteMapInner struct {
 func (inner *remoteMapInner) removeExpired(now time.Time, timeout time.Duration) {
 	for len(inner.byAge) > 0 && now.Sub(inner.byAge[0].LastSeen) >= timeout {
 		record := heap.Pop(inner).(*remoteRecord)
-		close(record.Closed)
+		record.sendMu.Lock()
+		record.expired = true
+		close(record.SendQueue)
+		record.sendMu.Unlock()
 	}
 }
 
@@ -144,7 +156,6 @@ func (inner *remoteMapInner) Lookup(addr net.Addr, now time.Time, queueSize int)
 			LastSeen:  now,
 			SendQueue: make(chan []byte, queueSize),
 			Stash:     make(chan []byte, 1),
-			Closed:    make(chan struct{}),
 		}
 		heap.Push(inner, record)
 	}

--- a/vaydns-client/main.go
+++ b/vaydns-client/main.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/net2share/vaydns/client"
 	"github.com/net2share/vaydns/dns"
 	"github.com/net2share/vaydns/noise"
 	"github.com/net2share/vaydns/turbotunnel"
+	log "github.com/sirupsen/logrus"
 )
 
 func readKeyFromFile(filename string) ([]byte, error) {
@@ -57,6 +57,7 @@ func main() {
 	var recordTypeStr string
 	var queueSize int
 	var kcpWindowSize int
+	var queueOverflowStr string
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), `Usage:
@@ -119,6 +120,7 @@ Known TLS fingerprints for -utls are:
 	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt, cname, a, aaaa, mx, ns, srv)")
 	flag.IntVar(&queueSize, "queue-size", turbotunnel.DefaultQueueSize, "packet queue size for transport and DNS layers")
 	flag.IntVar(&kcpWindowSize, "kcp-window-size", 0, "KCP send/receive window size in packets (0 = queue-size/2)")
+	flag.StringVar(&queueOverflowStr, "queue-overflow", string(turbotunnel.DefaultQueueOverflowMode), "queue overflow behavior: drop or block")
 
 	var logLevel string
 	flag.StringVar(&logLevel, "log-level", "warning", "log level (debug, info, warning, error)")
@@ -248,6 +250,11 @@ Known TLS fingerprints for -utls are:
 		fmt.Fprintf(os.Stderr, "invalid -udp-timeout: %v\n", err)
 		os.Exit(1)
 	}
+	queueOverflowMode, err := turbotunnel.ParseQueueOverflowMode(queueOverflowStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid -queue-overflow: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Validate.
 	if keepAlive >= idleTimeout {
@@ -363,7 +370,8 @@ Known TLS fingerprints for -utls are:
 	tunnel.SessionCheckInterval = sessionCheckInterval
 	tunnel.PacketQueueSize = queueSize
 	tunnel.KCPWindowSize = kcpWindowSize
-	log.Infof("transport sizing: queue-size=%d kcp-window-size=%d", queueSize, effectiveKCPWindowSize)
+	tunnel.QueueOverflowMode = queueOverflowMode
+	log.Infof("transport config: queue-size=%d kcp-window-size=%d queue-overflow=%s", queueSize, effectiveKCPWindowSize, queueOverflowMode)
 
 	if compatDnstt {
 		log.Infof("wire config: clientid-size=8 compat=true")

--- a/vaydns-client/main.go
+++ b/vaydns-client/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/net2share/vaydns/client"
 	"github.com/net2share/vaydns/dns"
 	"github.com/net2share/vaydns/noise"
+	"github.com/net2share/vaydns/turbotunnel"
 )
 
 func readKeyFromFile(filename string) ([]byte, error) {
@@ -54,6 +55,8 @@ func main() {
 	var compatDnstt bool
 	var clientIDSize int
 	var recordTypeStr string
+	var queueSize int
+	var kcpWindowSize int
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), `Usage:
@@ -114,6 +117,8 @@ Known TLS fingerprints for -utls are:
 	flag.BoolVar(&compatDnstt, "dnstt-compat", false, "use original dnstt wire format (8-byte ClientID, padding prefixes)")
 	flag.IntVar(&clientIDSize, "clientid-size", 2, "client ID size in bytes (ignored when -dnstt-compat is set)")
 	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt, cname, a, aaaa, mx, ns, srv)")
+	flag.IntVar(&queueSize, "queue-size", turbotunnel.DefaultQueueSize, "packet queue size for transport and DNS layers")
+	flag.IntVar(&kcpWindowSize, "kcp-window-size", 0, "KCP send/receive window size in packets (0 = queue-size/2)")
 
 	var logLevel string
 	flag.StringVar(&logLevel, "log-level", "warning", "log level (debug, info, warning, error)")
@@ -265,6 +270,25 @@ Known TLS fingerprints for -utls are:
 		fmt.Fprintf(os.Stderr, "-open-stream-timeout (%s) must be greater than 0\n", openStreamTimeout)
 		os.Exit(1)
 	}
+	if queueSize <= 0 {
+		fmt.Fprintf(os.Stderr, "-queue-size (%d) must be greater than 0\n", queueSize)
+		os.Exit(1)
+	}
+	if kcpWindowSize < 0 {
+		fmt.Fprintf(os.Stderr, "-kcp-window-size (%d) must be greater than or equal to 0\n", kcpWindowSize)
+		os.Exit(1)
+	}
+	if kcpWindowSize > queueSize {
+		fmt.Fprintf(os.Stderr, "-kcp-window-size (%d) must be less than or equal to -queue-size (%d)\n", kcpWindowSize, queueSize)
+		os.Exit(1)
+	}
+	effectiveKCPWindowSize := kcpWindowSize
+	if effectiveKCPWindowSize == 0 {
+		effectiveKCPWindowSize = queueSize / 2
+		if effectiveKCPWindowSize < 1 {
+			effectiveKCPWindowSize = 1
+		}
+	}
 
 	// Apply -dnstt-compat overrides.
 	if compatDnstt {
@@ -337,6 +361,9 @@ Known TLS fingerprints for -utls are:
 	tunnel.ReconnectMinDelay = reconnectMinDelay
 	tunnel.ReconnectMaxDelay = reconnectMaxDelay
 	tunnel.SessionCheckInterval = sessionCheckInterval
+	tunnel.PacketQueueSize = queueSize
+	tunnel.KCPWindowSize = kcpWindowSize
+	log.Infof("transport sizing: queue-size=%d kcp-window-size=%d", queueSize, effectiveKCPWindowSize)
 
 	if compatDnstt {
 		log.Infof("wire config: clientid-size=8 compat=true")

--- a/vaydns-server/main.go
+++ b/vaydns-server/main.go
@@ -311,7 +311,7 @@ func acceptStreams(conn *kcp.UDPSession, privkey []byte, upstream string, idleTi
 
 // acceptSessions listens for incoming KCP connections and passes them to
 // acceptStreams.
-func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int, upstream string, idleTimeout time.Duration, keepAlive time.Duration) error {
+func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int, upstream string, idleTimeout time.Duration, keepAlive time.Duration, kcpWindowSize int) error {
 	for {
 		conn, err := ln.AcceptKCP()
 		if err != nil {
@@ -331,7 +331,7 @@ func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int, upstream string, 
 			0, // default resend
 			1, // nc=1 => congestion window off
 		)
-		conn.SetWindowSize(turbotunnel.QueueSize/2, turbotunnel.QueueSize/2)
+		conn.SetWindowSize(kcpWindowSize, kcpWindowSize)
 		if rc := conn.SetMtu(mtu); !rc {
 			panic(rc)
 		}
@@ -1101,7 +1101,7 @@ func computeMaxEncodedPayloadMultiRR(limit int, chunkSize int) int {
 	return low
 }
 
-func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketConn, fallbackAddr *net.UDPAddr, idleTimeout time.Duration, keepAlive time.Duration, wireConfig turbotunnel.WireConfig) error {
+func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketConn, fallbackAddr *net.UDPAddr, idleTimeout time.Duration, keepAlive time.Duration, queueSize int, kcpWindowSize int, wireConfig turbotunnel.WireConfig) error {
 	defer dnsConn.Close()
 
 	log.Infof("pubkey %x", noise.PubkeyFromPrivkey(privkey))
@@ -1135,14 +1135,14 @@ func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketCon
 	log.Infof("effective MTU %d", mtu)
 
 	// Start up the virtual PacketConn for turbotunnel.
-	ttConn := turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, idleTimeout*2)
+	ttConn := turbotunnel.NewQueuePacketConnWithSize(turbotunnel.DummyAddr{}, idleTimeout*2, queueSize)
 	ln, err := kcp.ServeConn(nil, 0, 0, ttConn)
 	if err != nil {
 		return fmt.Errorf("opening KCP listener: %v", err)
 	}
 	defer ln.Close()
 	go func() {
-		err := acceptSessions(ln, privkey, mtu, upstream, idleTimeout, keepAlive)
+		err := acceptSessions(ln, privkey, mtu, upstream, idleTimeout, keepAlive, kcpWindowSize)
 		if err != nil {
 			log.Warnf("acceptSessions: %v", err)
 		}
@@ -1193,6 +1193,8 @@ func main() {
 	var compatDnstt bool
 	var clientIDSize int
 	var recordTypeStr string
+	var queueSize int
+	var kcpWindowSize int
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), `Usage:
@@ -1226,6 +1228,8 @@ Example:
 	flag.BoolVar(&compatDnstt, "dnstt-compat", false, "use original dnstt wire format (8-byte ClientID, padding prefixes)")
 	flag.IntVar(&clientIDSize, "clientid-size", 2, "client ID size in bytes (ignored when -dnstt-compat is set)")
 	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt, cname, a, aaaa, mx, ns, srv)")
+	flag.IntVar(&queueSize, "queue-size", turbotunnel.DefaultQueueSize, "packet queue size for DNS tunnel transport")
+	flag.IntVar(&kcpWindowSize, "kcp-window-size", 0, "KCP send/receive window size in packets (0 = queue-size/2)")
 
 	var logLevel string
 	flag.StringVar(&logLevel, "log-level", "warning", "log level (debug, info, warning, error)")
@@ -1248,7 +1252,7 @@ Example:
 
 	if genKey {
 		// -gen-key mode.
-		if flag.NArg() != 0 || privkeyString != "" || udpAddr != "" || fallbackAddrString != "" || domainArg != "" || upstream != "" || idleTimeoutStr != defaultIdleTimeout.String() || keepAliveStr != defaultKeepAlive.String() {
+		if flag.NArg() != 0 || privkeyString != "" || udpAddr != "" || fallbackAddrString != "" || domainArg != "" || upstream != "" || idleTimeoutStr != defaultIdleTimeout.String() || keepAliveStr != defaultKeepAlive.String() || queueSize != turbotunnel.DefaultQueueSize || kcpWindowSize != 0 {
 			flag.Usage()
 			os.Exit(1)
 		}
@@ -1374,6 +1378,25 @@ Example:
 			fmt.Fprintf(os.Stderr, "-keepalive (%s) must be less than -idle-timeout (%s)\n", keepAlive, idleTimeout)
 			os.Exit(1)
 		}
+		if queueSize <= 0 {
+			fmt.Fprintf(os.Stderr, "-queue-size (%d) must be greater than 0\n", queueSize)
+			os.Exit(1)
+		}
+		if kcpWindowSize < 0 {
+			fmt.Fprintf(os.Stderr, "-kcp-window-size (%d) must be greater than or equal to 0\n", kcpWindowSize)
+			os.Exit(1)
+		}
+		if kcpWindowSize == 0 {
+			kcpWindowSize = queueSize / 2
+			if kcpWindowSize < 1 {
+				kcpWindowSize = 1
+			}
+		}
+		if kcpWindowSize > queueSize {
+			fmt.Fprintf(os.Stderr, "-kcp-window-size (%d) must be less than or equal to -queue-size (%d)\n", kcpWindowSize, queueSize)
+			os.Exit(1)
+		}
+		log.Infof("transport sizing: queue-size=%d kcp-window-size=%d", queueSize, kcpWindowSize)
 
 		var wireConfig turbotunnel.WireConfig
 		if compatDnstt {
@@ -1418,7 +1441,7 @@ Example:
 			}
 		}
 
-		err = run(privkey, domain, upstream, dnsConn, fallbackAddr, idleTimeout, keepAlive, wireConfig)
+		err = run(privkey, domain, upstream, dnsConn, fallbackAddr, idleTimeout, keepAlive, queueSize, kcpWindowSize, wireConfig)
 		if err != nil {
 			log.Fatalf("%v", err)
 		}

--- a/vaydns-server/main.go
+++ b/vaydns-server/main.go
@@ -1101,7 +1101,7 @@ func computeMaxEncodedPayloadMultiRR(limit int, chunkSize int) int {
 	return low
 }
 
-func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketConn, fallbackAddr *net.UDPAddr, idleTimeout time.Duration, keepAlive time.Duration, queueSize int, kcpWindowSize int, wireConfig turbotunnel.WireConfig) error {
+func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketConn, fallbackAddr *net.UDPAddr, idleTimeout time.Duration, keepAlive time.Duration, queueSize int, queueOverflowMode turbotunnel.QueueOverflowMode, kcpWindowSize int, wireConfig turbotunnel.WireConfig) error {
 	defer dnsConn.Close()
 
 	log.Infof("pubkey %x", noise.PubkeyFromPrivkey(privkey))
@@ -1135,7 +1135,10 @@ func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketCon
 	log.Infof("effective MTU %d", mtu)
 
 	// Start up the virtual PacketConn for turbotunnel.
-	ttConn := turbotunnel.NewQueuePacketConnWithSize(turbotunnel.DummyAddr{}, idleTimeout*2, queueSize)
+	ttConn := turbotunnel.NewQueuePacketConnWithConfig(turbotunnel.DummyAddr{}, idleTimeout*2, turbotunnel.QueuePacketConnConfig{
+		QueueSize:    queueSize,
+		OverflowMode: queueOverflowMode,
+	})
 	ln, err := kcp.ServeConn(nil, 0, 0, ttConn)
 	if err != nil {
 		return fmt.Errorf("opening KCP listener: %v", err)
@@ -1195,6 +1198,7 @@ func main() {
 	var recordTypeStr string
 	var queueSize int
 	var kcpWindowSize int
+	var queueOverflowStr string
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), `Usage:
@@ -1230,6 +1234,7 @@ Example:
 	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt, cname, a, aaaa, mx, ns, srv)")
 	flag.IntVar(&queueSize, "queue-size", turbotunnel.DefaultQueueSize, "packet queue size for DNS tunnel transport")
 	flag.IntVar(&kcpWindowSize, "kcp-window-size", 0, "KCP send/receive window size in packets (0 = queue-size/2)")
+	flag.StringVar(&queueOverflowStr, "queue-overflow", string(turbotunnel.DefaultQueueOverflowMode), "queue overflow behavior: drop or block")
 
 	var logLevel string
 	flag.StringVar(&logLevel, "log-level", "warning", "log level (debug, info, warning, error)")
@@ -1249,10 +1254,15 @@ Example:
 		os.Exit(1)
 	}
 	recordType = rt
+	queueOverflowMode, err := turbotunnel.ParseQueueOverflowMode(queueOverflowStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid -queue-overflow: %v\n", err)
+		os.Exit(1)
+	}
 
 	if genKey {
 		// -gen-key mode.
-		if flag.NArg() != 0 || privkeyString != "" || udpAddr != "" || fallbackAddrString != "" || domainArg != "" || upstream != "" || idleTimeoutStr != defaultIdleTimeout.String() || keepAliveStr != defaultKeepAlive.String() || queueSize != turbotunnel.DefaultQueueSize || kcpWindowSize != 0 {
+		if flag.NArg() != 0 || privkeyString != "" || udpAddr != "" || fallbackAddrString != "" || domainArg != "" || upstream != "" || idleTimeoutStr != defaultIdleTimeout.String() || keepAliveStr != defaultKeepAlive.String() || queueSize != turbotunnel.DefaultQueueSize || kcpWindowSize != 0 || queueOverflowMode != turbotunnel.DefaultQueueOverflowMode {
 			flag.Usage()
 			os.Exit(1)
 		}
@@ -1396,7 +1406,7 @@ Example:
 			fmt.Fprintf(os.Stderr, "-kcp-window-size (%d) must be less than or equal to -queue-size (%d)\n", kcpWindowSize, queueSize)
 			os.Exit(1)
 		}
-		log.Infof("transport sizing: queue-size=%d kcp-window-size=%d", queueSize, kcpWindowSize)
+		log.Infof("transport config: queue-size=%d kcp-window-size=%d queue-overflow=%s", queueSize, kcpWindowSize, queueOverflowMode)
 
 		var wireConfig turbotunnel.WireConfig
 		if compatDnstt {
@@ -1441,7 +1451,7 @@ Example:
 			}
 		}
 
-		err = run(privkey, domain, upstream, dnsConn, fallbackAddr, idleTimeout, keepAlive, queueSize, kcpWindowSize, wireConfig)
+		err = run(privkey, domain, upstream, dnsConn, fallbackAddr, idleTimeout, keepAlive, queueSize, queueOverflowMode, kcpWindowSize, wireConfig)
 		if err != nil {
 			log.Fatalf("%v", err)
 		}


### PR DESCRIPTION
## Summary

This patch set fixes two related problems in the client tunnel path:

1. recovery gaps that could leave the client alive but unable to reconnect without manual restart
2. overload behavior that made the single shared session too fragile under load

The final result is a more aggressive transport rebuild when the lower stack is actually broken, while preserving the shared session when the failure is only local to one connection. It also keeps the original lossy queue semantics as the default for KCP-over-DNS, while adding runtime controls for queue size, queue overflow mode, and KCP window size.

## Problem

The tunnel currently uses one shared smux session for all local connections. That creates two failure classes:

- if the lower transport becomes poisoned, reconnect must rebuild more than just `KCP -> Noise -> smux`
- if the client kills that one shared session too aggressively, every active connection is dropped at once

There was also a transport overload problem:

- internal packet queues were small and fixed at build time
- queue overflow silently dropped packets while still reporting success
- under load, that local loss could destabilize KCP and cause avoidable stream-open failures and session churn

## Root Cause

Recovery logic was previously scoped too high in the stack, while overload handling was scoped too low.

Recovery issue:

- reconnect recreated the session layers, but could reuse stale resolver and `DNSPacketConn` state

Reliability issue:

- the shared session rode on top of small local queues with silent drop-on-full behavior
- a single connection error could be escalated into a full-session failure

## What Changed

### Recovery hardening

- rebuild the transport stack from the resolver upward on reconnect
- surface fatal DNS transport errors into the session loop
- make `OpenStream` timeout bounded and close late-arriving streams to avoid leaks
- make transport worker goroutines exit cleanly on close

### Shared-session reliability

- stop treating per-connection failures as automatic session failures
- keep `OpenStream` timeout local to the failed connection attempt
- unblock paired copy goroutines during teardown so stuck handlers do not pin stream capacity

### Overload handling and tunability

- increase default queue capacity from `128` to `1024`
- add runtime flags on both client and server:
  - `-queue-size`
  - `-queue-overflow`
  - `-kcp-window-size`
- keep `drop` as the default queue overflow mode and allow optional `block`
- support `-kcp-window-size=0` as auto-size from `queue-size / 2`
- validate the new flags and log the effective transport sizing at startup

## Before / After

Before:

- reconnect could reuse poisoned lower transport state
- some failures required manual restart to recover
- one bad connection could take down the shared session
- transport workers could outlive the transport they belonged to
- queue overflow silently discarded packets
- queue and KCP sizing were fixed at build time

After:

- reconnect rebuilds the full lower transport path when needed
- per-connection failures stay local when the session is still healthy
- transport errors reach the reconnect path instead of being hidden
- worker shutdown is cleaner across reconnect cycles
- overload handling is explicit and tunable, with lossy `drop` as the default
- queue and KCP sizing can be tuned at runtime on both sides

## Why This Fix Is Correct

For this tunnel design, both recovery and reliability are required:

- recovery without reliability causes the client to reconnect often but still drop the shared session too easily
- reliability without recovery leaves the client stuck after lower-layer transport failure

This patch set addresses both sides of that problem:

- it rebuilds truly broken transport state
- it avoids destroying the session for failures that are only local to one stream
- it stops the transport from silently losing its own packets under load

## Validation

Validated through production testing of the patched client/server path, including repeated stream-open failure scenarios and reconnect behavior. Recovery is faster and session behavior under load is materially more stable with the larger, configurable transport capacity while keeping lossy queue overflow as the default behavior.

## Scope

Primary target:

- pure UDP transport
- client/server `KCP`
- client `Noise`
- client/server `smux` session handling

Secondary impact:

- DoH and DoT transport constructors now accept queue sizing too, for consistency

## Files

- `client/client.go`
- `client/dns.go`
- `client/http.go`
- `client/tls.go`
- `client/udp.go`
- `turbotunnel/consts.go`
- `turbotunnel/queuepacketconn.go`
- `turbotunnel/remotemap.go`
- `vaydns-client/main.go`
- `vaydns-server/main.go`