### PR TITLE
fix(logging): default to info and rate-limit forged DNS logs with milestone summaries

### DIFF
--- a/client/dns.go
+++ b/client/dns.go
@@ -99,10 +99,10 @@ func (rl *RateLimiter) Wait() {
 // UDPPacketConn (per-query mode) and DNSPacketConn (shared socket mode) so
 // that forged response visibility is consistent regardless of transport.
 type ForgedStats struct {
-	Total     uint64
-	SERVFAIL  uint64
-	NXDOMAIN  uint64
-	Other     uint64
+	Total    uint64
+	SERVFAIL uint64
+	NXDOMAIN uint64
+	Other    uint64
 }
 
 // Record increments the appropriate counter for the given RCODE and logs
@@ -117,7 +117,7 @@ func (s *ForgedStats) Record(rcode uint16) {
 		atomic.AddUint64(&s.Other, 1)
 	}
 	total := atomic.AddUint64(&s.Total, 1)
-	log.Infof("forged DNS response (rcode=%d, total forged=%d, SERVFAIL=%d, NXDOMAIN=%d, other=%d)",
+	log.Debugf("forged DNS response (rcode=%d, total forged=%d, SERVFAIL=%d, NXDOMAIN=%d, other=%d)",
 		rcode, total,
 		atomic.LoadUint64(&s.SERVFAIL),
 		atomic.LoadUint64(&s.NXDOMAIN),

--- a/client/dns.go
+++ b/client/dns.go
@@ -44,6 +44,11 @@ const (
 // base32Encoding is a base32 encoding without padding.
 var base32Encoding = base32.StdEncoding.WithPadding(base32.NoPadding)
 
+// forgedInfoMilestones defines the exact totals at which an INFO log is
+// emitted. After the last explicit milestone the interval logic in
+// forgedInfoMilestone takes over.
+var forgedInfoMilestones = [...]uint64{10, 100, 500, 1000, 2500, 5000}
+
 // RateLimiter implements a token bucket rate limiter for DNS queries.
 type RateLimiter struct {
 	mu       sync.Mutex
@@ -106,7 +111,8 @@ type ForgedStats struct {
 }
 
 // Record increments the appropriate counter for the given RCODE and logs
-// a summary at info level.
+// a summary at INFO level at milestone counts. Non-milestone forged
+// responses are silently counted.
 func (s *ForgedStats) Record(rcode uint16) {
 	switch rcode {
 	case dns.RcodeServerFailure:
@@ -117,11 +123,29 @@ func (s *ForgedStats) Record(rcode uint16) {
 		atomic.AddUint64(&s.Other, 1)
 	}
 	total := atomic.AddUint64(&s.Total, 1)
-	log.Debugf("forged DNS response (rcode=%d, total forged=%d, SERVFAIL=%d, NXDOMAIN=%d, other=%d)",
-		rcode, total,
-		atomic.LoadUint64(&s.SERVFAIL),
-		atomic.LoadUint64(&s.NXDOMAIN),
-		atomic.LoadUint64(&s.Other))
+	if forgedInfoMilestone(total) {
+		log.Infof("forged DNS responses: total=%d, SERVFAIL=%d, NXDOMAIN=%d, other=%d",
+			total,
+			atomic.LoadUint64(&s.SERVFAIL),
+			atomic.LoadUint64(&s.NXDOMAIN),
+			atomic.LoadUint64(&s.Other))
+	}
+}
+
+func forgedInfoMilestone(total uint64) bool {
+	for _, m := range forgedInfoMilestones {
+		if total == m {
+			return true
+		}
+	}
+	switch {
+	case total <= 100_000:
+		return total%10_000 == 0
+	case total <= 1_000_000:
+		return total%50_000 == 0
+	default:
+		return total%100_000 == 0
+	}
 }
 
 // DNSPacketConn provides a packet-sending and -receiving interface over various

--- a/vaydns-client/main.go
+++ b/vaydns-client/main.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/net2share/vaydns/client"
 	"github.com/net2share/vaydns/dns"
 	"github.com/net2share/vaydns/noise"
+	log "github.com/sirupsen/logrus"
 )
 
 func readKeyFromFile(filename string) ([]byte, error) {
@@ -116,7 +116,7 @@ Known TLS fingerprints for -utls are:
 	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt, cname, a, aaaa, mx, ns, srv)")
 
 	var logLevel string
-	flag.StringVar(&logLevel, "log-level", "warning", "log level (debug, info, warning, error)")
+	flag.StringVar(&logLevel, "log-level", "info", "log level (debug, info, warning, error)")
 	flag.Parse()
 
 	level, err := log.ParseLevel(logLevel)

--- a/vaydns-server/main.go
+++ b/vaydns-server/main.go
@@ -65,11 +65,11 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/xtaci/kcp-go/v5"
-	"github.com/xtaci/smux"
 	"github.com/net2share/vaydns/dns"
 	"github.com/net2share/vaydns/noise"
 	"github.com/net2share/vaydns/turbotunnel"
+	"github.com/xtaci/kcp-go/v5"
+	"github.com/xtaci/smux"
 )
 
 const (
@@ -1228,7 +1228,7 @@ Example:
 	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt, cname, a, aaaa, mx, ns, srv)")
 
 	var logLevel string
-	flag.StringVar(&logLevel, "log-level", "warning", "log level (debug, info, warning, error)")
+	flag.StringVar(&logLevel, "log-level", "info", "log level (debug, info, warning, error)")
 	flag.Parse()
 
 	level, err := log.ParseLevel(logLevel)


### PR DESCRIPTION
  ## Summary
  This PR includes two logging updates:

  1. Default log level is now `info` for both binaries:
     - `vaydns-client/main.go`
     - `vaydns-server/main.go`

  2. Forged DNS response logging in `client/dns.go` is changed from per-response output to milestone-based INFO summaries.

  ## Forged logging behavior
  Forged responses are always counted, but INFO logs are emitted only when total forged reaches:
  - Explicit milestones: `10, 100, 500, 1000, 2500, 5000`
  - Every `10,000` from `10,000` to `100,000`
  - Every `50,000` from `100,000` to `1,000,000`
  - Every `100,000` after `1,000,000`

  Non-milestone forged responses produce no log output (including DEBUG).

  ## Why
  - Prevent stderr spam under active forgery.
  - Keep forged-activity visibility at `info` level.
  - Preserve visibility of operational logs (session lifecycle, stream creation, reconnect events).

  ## Impact
  - No change to forged-response detection or counters (`Total`, `SERVFAIL`, `NXDOMAIN`, `Other`).
  - Lower log volume under forge-heavy resolvers while still surfacing meaningful aggregate milestones.
