### PR TITLE
fix(client): goroutine and connection leak in the DoT transport during reconnect cycles

### DIFF
--- a/client/tls.go
+++ b/client/tls.go
@@ -30,6 +30,8 @@ type TLSPacketConn struct {
 	// recvLoop and sendLoop take the messages out of the receive and send
 	// queues and actually put them on the network.
 	*turbotunnel.QueuePacketConn
+	connMu sync.Mutex
+	conn   net.Conn
 }
 
 // NewTLSPacketConn creates a new TLSPacketConn configured to use the TLS
@@ -53,6 +55,7 @@ func NewTLSPacketConn(addr string, dialTLSContext func(ctx context.Context, netw
 	c := &TLSPacketConn{
 		QueuePacketConn: turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, 0),
 	}
+	c.setConn(conn)
 	go func() {
 		defer c.Close()
 		for {
@@ -73,7 +76,14 @@ func NewTLSPacketConn(addr string, dialTLSContext func(ctx context.Context, netw
 				wg.Done()
 			}()
 			wg.Wait()
+			c.clearConn(conn)
 			conn.Close()
+
+			select {
+			case <-c.Closed():
+				return
+			default:
+			}
 
 			// Whenever the TLS connection dies, redial a new one.
 			conn, err = dial()
@@ -81,9 +91,48 @@ func NewTLSPacketConn(addr string, dialTLSContext func(ctx context.Context, netw
 				log.Errorf("dial tls: %v", err)
 				break
 			}
+
+			select {
+			case <-c.Closed():
+				conn.Close()
+				return
+			default:
+			}
+			c.setConn(conn)
 		}
 	}()
 	return c, nil
+}
+
+func (c *TLSPacketConn) setConn(conn net.Conn) {
+	c.connMu.Lock()
+	c.conn = conn
+	c.connMu.Unlock()
+}
+
+func (c *TLSPacketConn) clearConn(conn net.Conn) {
+	c.connMu.Lock()
+	if c.conn == conn {
+		c.conn = nil
+	}
+	c.connMu.Unlock()
+}
+
+func (c *TLSPacketConn) closeActiveConn() {
+	c.connMu.Lock()
+	conn := c.conn
+	c.conn = nil
+	c.connMu.Unlock()
+	if conn != nil {
+		conn.Close()
+	}
+}
+
+// Close tears down both the packet queue and any active TLS connection,
+// ensuring the reconnect goroutine exits.
+func (c *TLSPacketConn) Close() error {
+	c.closeActiveConn()
+	return c.QueuePacketConn.Close()
 }
 
 // recvLoop reads length-prefixed messages from conn and passes them to the


### PR DESCRIPTION
## Summary

Fix goroutine and connection leak in the DoT (DNS over TLS) transport during reconnect cycles.

The reconnect goroutine in `TLSPacketConn` had no way to detect that the transport was closed externally. After `sendLoop` exits via the closed channel, `wg.Wait()` returns and the loop immediately redials a new TLS connection — even if the transport has already been torn down by `resetTransportLayers`. Each reconnect cycle leaks one goroutine and potentially one TCP connection.

## What changed

- Track the active TLS connection under a mutex (`connMu` + `conn` field)
- Check `Closed()` after the send/recv loops finish and again after a successful redial, so the goroutine exits instead of spinning
- Override `Close()` to tear down both the active TLS connection and the `QueuePacketConn`, ensuring the reconnect goroutine can't outlive the transport

## Why

Without this, every transport rebuild (`resetTransportLayers`) during client reconnect leaks one TLS goroutine. Under censored networks where reconnects are frequent, this compounds over time.

Only affects DoT — DoH uses stateless HTTP round-trips with no persistent connection or reconnect loop.

## Files

- `client/tls.go`
