### PR TITLE
  feat: make transport queue and KCP window sizes configurable

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -202,6 +202,8 @@ type Tunnel struct {
 	ReconnectMaxDelay    time.Duration // default: 30s
 	SessionCheckInterval time.Duration // default: 20s
 	HandshakeTimeout     time.Duration // default: 30s
+	PacketQueueSize      int           // default: QueueSize (512)
+	KCPWindowSize        int           // default: PacketQueueSize/2
 
 	// internal state
 	wireConfig    turbotunnel.WireConfig
@@ -262,6 +264,24 @@ func (t *Tunnel) applyDefaults() {
 	}
 }
 
+func (t *Tunnel) effectivePacketQueueSize() int {
+	if t.PacketQueueSize > 0 {
+		return t.PacketQueueSize
+	}
+	return turbotunnel.QueueSize
+}
+
+func (t *Tunnel) effectiveKCPWindowSize() int {
+	if t.KCPWindowSize > 0 {
+		return t.KCPWindowSize
+	}
+	ws := t.effectivePacketQueueSize() / 2
+	if ws < 1 {
+		ws = 1
+	}
+	return ws
+}
+
 // InitiateResolverConnection creates the underlying transport connection
 // based on the Resolver configuration.
 func (t *Tunnel) InitiateResolverConnection() error {
@@ -289,7 +309,7 @@ func (t *Tunnel) InitiateResolverConnection() error {
 			if timeout <= 0 {
 				timeout = DefaultUDPResponseTimeout
 			}
-			conn, forgedStats, err := NewUDPPacketConn(addr, r.DialerControl, workers, timeout, !r.UDPAcceptErrors)
+			conn, forgedStats, err := NewUDPPacketConn(addr, r.DialerControl, workers, timeout, !r.UDPAcceptErrors, t.effectivePacketQueueSize())
 			if err != nil {
 				return err
 			}
@@ -308,7 +328,7 @@ func (t *Tunnel) InitiateResolverConnection() error {
 		} else {
 			rt = http.DefaultTransport
 		}
-		conn, err := NewHTTPPacketConn(rt, r.ResolverAddr, 8)
+		conn, err := NewHTTPPacketConn(rt, r.ResolverAddr, 8, t.effectivePacketQueueSize())
 		if err != nil {
 			return err
 		}
@@ -328,7 +348,7 @@ func (t *Tunnel) InitiateResolverConnection() error {
 				return tls.DialWithDialer(&net.Dialer{}, network, addr, nil)
 			}
 		}
-		conn, err := NewTLSPacketConn(r.ResolverAddr, dialTLSContext)
+		conn, err := NewTLSPacketConn(r.ResolverAddr, dialTLSContext, t.effectivePacketQueueSize())
 		if err != nil {
 			return err
 		}
@@ -348,7 +368,7 @@ func (t *Tunnel) InitiateDNSPacketConn(domain dns.Name) error {
 	}
 	maxQnameLen := t.TunnelServer.effectiveMaxQnameLen()
 	rrType := t.TunnelServer.effectiveRRType()
-	t.dnsPacketConn = NewDNSPacketConn(t.resolverConn, t.remoteAddr, domain, rateLimiter, maxQnameLen, t.TunnelServer.MaxNumLabels, t.wireConfig, t.forgedStats, rrType)
+	t.dnsPacketConn = NewDNSPacketConn(t.resolverConn, t.remoteAddr, domain, rateLimiter, maxQnameLen, t.TunnelServer.MaxNumLabels, t.wireConfig, t.forgedStats, rrType, t.effectivePacketQueueSize())
 	return nil
 }
 
@@ -373,7 +393,7 @@ func (t *Tunnel) InitiateKCPConn(mtu int) error {
 	log.Infof("session %08x ready", conn.GetConv())
 	conn.SetStreamMode(true)
 	conn.SetNoDelay(0, 0, 0, 1)
-	conn.SetWindowSize(turbotunnel.QueueSize/2, turbotunnel.QueueSize/2)
+	conn.SetWindowSize(t.effectiveKCPWindowSize(), t.effectiveKCPWindowSize())
 	if rc := conn.SetMtu(mtu); !rc {
 		conn.Close()
 		return fmt.Errorf("failed to set KCP MTU to %d", mtu)
@@ -708,7 +728,7 @@ func (t *Tunnel) createSession(mtu int) (*kcp.UDPSession, *smux.Session, error) 
 	log.Infof("session %08x ready", conn.GetConv())
 	conn.SetStreamMode(true)
 	conn.SetNoDelay(0, 0, 0, 1)
-	conn.SetWindowSize(turbotunnel.QueueSize/2, turbotunnel.QueueSize/2)
+	conn.SetWindowSize(t.effectiveKCPWindowSize(), t.effectiveKCPWindowSize())
 	if rc := conn.SetMtu(mtu); !rc {
 		conn.Close()
 		return nil, nil, fmt.Errorf("failed to set KCP MTU to %d", mtu)

--- a/client/dns.go
+++ b/client/dns.go
@@ -195,7 +195,7 @@ type DNSPacketConn struct {
 // maxNumLabels is the max number of data labels (0 = unlimited).
 // forgedStats is shared with the transport layer (e.g. UDPPacketConn) for
 // consistent forged response tracking; if nil, a new instance is created.
-func NewDNSPacketConn(transport net.PacketConn, addr net.Addr, domain dns.Name, rateLimiter *RateLimiter, maxQnameLen int, maxNumLabels int, wireConfig turbotunnel.WireConfig, forgedStats *ForgedStats, rrType uint16) *DNSPacketConn {
+func NewDNSPacketConn(transport net.PacketConn, addr net.Addr, domain dns.Name, rateLimiter *RateLimiter, maxQnameLen int, maxNumLabels int, wireConfig turbotunnel.WireConfig, forgedStats *ForgedStats, rrType uint16, queueSize int) *DNSPacketConn {
 	if maxQnameLen <= 0 || maxQnameLen > 253 {
 		maxQnameLen = 253
 	}
@@ -218,7 +218,7 @@ func NewDNSPacketConn(transport net.PacketConn, addr net.Addr, domain dns.Name, 
 		maxNumLabels:    maxNumLabels,
 		forgedStats:     forgedStats,
 		transportErr:    make(chan error, 2),
-		QueuePacketConn: turbotunnel.NewQueuePacketConn(clientID, 0),
+		QueuePacketConn: turbotunnel.NewQueuePacketConn(clientID, 0, queueSize),
 	}
 	go func() {
 		err := c.recvLoop(transport)

--- a/client/http.go
+++ b/client/http.go
@@ -58,14 +58,14 @@ type HTTPPacketConn struct {
 // that will be used to make requests. urlString should include any necessary
 // path components; e.g., "/dns-query". numSenders is the number of concurrent
 // sender-receiver goroutines to run.
-func NewHTTPPacketConn(rt http.RoundTripper, urlString string, numSenders int) (*HTTPPacketConn, error) {
+func NewHTTPPacketConn(rt http.RoundTripper, urlString string, numSenders int, queueSize int) (*HTTPPacketConn, error) {
 	c := &HTTPPacketConn{
 		client: &http.Client{
 			Transport: rt,
 			Timeout:   1 * time.Minute,
 		},
 		urlString:       urlString,
-		QueuePacketConn: turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, 0),
+		QueuePacketConn: turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, 0, queueSize),
 	}
 	for i := 0; i < numSenders; i++ {
 		go c.sendLoop()

--- a/client/tls.go
+++ b/client/tls.go
@@ -38,7 +38,7 @@ type TLSPacketConn struct {
 // server at addr as a DNS over TLS resolver. It maintains a TLS connection to
 // the resolver, reconnecting as necessary. It closes the connection if any
 // reconnection attempt fails.
-func NewTLSPacketConn(addr string, dialTLSContext func(ctx context.Context, network, addr string) (net.Conn, error)) (*TLSPacketConn, error) {
+func NewTLSPacketConn(addr string, dialTLSContext func(ctx context.Context, network, addr string) (net.Conn, error), queueSize int) (*TLSPacketConn, error) {
 	dial := func() (net.Conn, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
 		defer cancel()
@@ -53,7 +53,7 @@ func NewTLSPacketConn(addr string, dialTLSContext func(ctx context.Context, netw
 		return nil, err
 	}
 	c := &TLSPacketConn{
-		QueuePacketConn: turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, 0),
+		QueuePacketConn: turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, 0, queueSize),
 	}
 	c.setConn(conn)
 	go func() {

--- a/client/udp.go
+++ b/client/udp.go
@@ -36,7 +36,7 @@ type UDPPacketConn struct {
 // each send one query at a time on a fresh UDP socket. The returned
 // ForgedStats pointer is shared with the caller so DNSPacketConn can
 // include per-query forged counts in its reporting.
-func NewUDPPacketConn(remoteAddr net.Addr, dialerControl func(network, address string, c syscall.RawConn) error, numWorkers int, responseTimeout time.Duration, ignoreErrors bool) (*UDPPacketConn, *ForgedStats, error) {
+func NewUDPPacketConn(remoteAddr net.Addr, dialerControl func(network, address string, c syscall.RawConn) error, numWorkers int, responseTimeout time.Duration, ignoreErrors bool, queueSize int) (*UDPPacketConn, *ForgedStats, error) {
 	stats := &ForgedStats{}
 	pconn := &UDPPacketConn{
 		remoteAddr:      remoteAddr,
@@ -44,7 +44,7 @@ func NewUDPPacketConn(remoteAddr net.Addr, dialerControl func(network, address s
 		responseTimeout: responseTimeout,
 		ignoreErrors:    ignoreErrors,
 		forgedStats:     stats,
-		QueuePacketConn: turbotunnel.NewQueuePacketConn(remoteAddr, 0),
+		QueuePacketConn: turbotunnel.NewQueuePacketConn(remoteAddr, 0, queueSize),
 	}
 	for i := 0; i < numWorkers; i++ {
 		go pconn.sendLoop()

--- a/turbotunnel/queuepacketconn.go
+++ b/turbotunnel/queuepacketconn.go
@@ -43,12 +43,16 @@ type QueuePacketConn struct {
 }
 
 // NewQueuePacketConn makes a new QueuePacketConn, set to track recent peers
-// for at least a duration of timeout.
-func NewQueuePacketConn(localAddr net.Addr, timeout time.Duration) *QueuePacketConn {
+// for at least a duration of timeout. If queueSize is <= 0, the default
+// QueueSize is used.
+func NewQueuePacketConn(localAddr net.Addr, timeout time.Duration, queueSize int) *QueuePacketConn {
+	if queueSize <= 0 {
+		queueSize = QueueSize
+	}
 	return &QueuePacketConn{
-		remotes:   NewRemoteMap(timeout),
+		remotes:   NewRemoteMap(timeout, queueSize),
 		localAddr: localAddr,
-		recvQueue: make(chan taggedPacket, QueueSize),
+		recvQueue: make(chan taggedPacket, queueSize),
 		closed:    make(chan struct{}),
 	}
 }
@@ -119,12 +123,24 @@ func (c *QueuePacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
 	// Copy the slice so that the caller may reuse it.
 	buf := make([]byte, len(p))
 	copy(buf, p)
-	select {
-	case c.remotes.SendQueue(addr) <- buf:
-		return len(buf), nil
-	default:
-		// Drop the outgoing packet if the send queue is full.
-		return len(buf), nil
+	for {
+		record := c.remotes.lookup(addr)
+		record.sendMu.Lock()
+		if record.expired {
+			// The record was expired while we looked it up. Get a
+			// fresh one and try again.
+			record.sendMu.Unlock()
+			continue
+		}
+		select {
+		case record.SendQueue <- buf:
+			record.sendMu.Unlock()
+			return len(buf), nil
+		default:
+			// Drop the outgoing packet if the send queue is full.
+			record.sendMu.Unlock()
+			return len(buf), nil
+		}
 	}
 }
 

--- a/turbotunnel/remotemap.go
+++ b/turbotunnel/remotemap.go
@@ -14,6 +14,8 @@ type remoteRecord struct {
 	LastSeen  time.Time
 	SendQueue chan []byte
 	Stash     chan []byte
+	sendMu    sync.Mutex
+	expired   bool
 }
 
 // RemoteMap manages a mapping of live remote peers, keyed by address, to their
@@ -30,6 +32,8 @@ type RemoteMap struct {
 	inner remoteMapInner
 	// Synchronizes access to inner.
 	lock sync.Mutex
+	// queueSize is the capacity for each remote's send queue.
+	queueSize int
 }
 
 // NewRemoteMap creates a RemoteMap that expires peers after a timeout.
@@ -42,12 +46,16 @@ type RemoteMap struct {
 // time. If smux later decides to send more packets to the same peer, we'll
 // instantiate a new send queue, and if the peer is ever seen again with a
 // matching address, we'll deliver them.
-func NewRemoteMap(timeout time.Duration) *RemoteMap {
+func NewRemoteMap(timeout time.Duration, queueSize int) *RemoteMap {
+	if queueSize <= 0 {
+		queueSize = QueueSize
+	}
 	m := &RemoteMap{
 		inner: remoteMapInner{
 			byAge:  make([]*remoteRecord, 0),
 			byAddr: make(map[net.Addr]int),
 		},
+		queueSize: queueSize,
 	}
 	if timeout > 0 {
 		go func() {
@@ -68,7 +76,16 @@ func NewRemoteMap(timeout time.Duration) *RemoteMap {
 func (m *RemoteMap) SendQueue(addr net.Addr) chan []byte {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return m.inner.Lookup(addr, time.Now()).SendQueue
+	return m.inner.Lookup(addr, time.Now(), m.queueSize).SendQueue
+}
+
+// lookup returns the full remote record corresponding to addr, creating it if
+// necessary. The caller can use the record's sendMu to safely write to
+// SendQueue without racing with removeExpired.
+func (m *RemoteMap) lookup(addr net.Addr) *remoteRecord {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.inner.Lookup(addr, time.Now(), m.queueSize)
 }
 
 // Stash places p in the stash corresponding to addr, if the stash is not
@@ -78,7 +95,7 @@ func (m *RemoteMap) Stash(addr net.Addr, p []byte) bool {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	select {
-	case m.inner.Lookup(addr, time.Now()).Stash <- p:
+	case m.inner.Lookup(addr, time.Now(), m.queueSize).Stash <- p:
 		return true
 	default:
 		return false
@@ -89,7 +106,7 @@ func (m *RemoteMap) Stash(addr net.Addr, p []byte) bool {
 func (m *RemoteMap) Unstash(addr net.Addr) <-chan []byte {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	return m.inner.Lookup(addr, time.Now()).Stash
+	return m.inner.Lookup(addr, time.Now(), m.queueSize).Stash
 }
 
 // remoteMapInner is the inner type of RemoteMap, implementing heap.Interface.
@@ -107,14 +124,17 @@ type remoteMapInner struct {
 func (inner *remoteMapInner) removeExpired(now time.Time, timeout time.Duration) {
 	for len(inner.byAge) > 0 && now.Sub(inner.byAge[0].LastSeen) >= timeout {
 		record := heap.Pop(inner).(*remoteRecord)
+		record.sendMu.Lock()
+		record.expired = true
 		close(record.SendQueue)
+		record.sendMu.Unlock()
 	}
 }
 
 // Lookup finds the existing record corresponding to addr, or creates a new
 // one if none exists yet. It updates the record's LastSeen time and returns the
 // record.
-func (inner *remoteMapInner) Lookup(addr net.Addr, now time.Time) *remoteRecord {
+func (inner *remoteMapInner) Lookup(addr net.Addr, now time.Time, queueSize int) *remoteRecord {
 	var record *remoteRecord
 	i, ok := inner.byAddr[addr]
 	if ok {
@@ -127,7 +147,7 @@ func (inner *remoteMapInner) Lookup(addr net.Addr, now time.Time) *remoteRecord 
 		record = &remoteRecord{
 			Addr:      addr,
 			LastSeen:  now,
-			SendQueue: make(chan []byte, QueueSize),
+			SendQueue: make(chan []byte, queueSize),
 			Stash:     make(chan []byte, 1),
 		}
 		heap.Push(inner, record)

--- a/vaydns-client/main.go
+++ b/vaydns-client/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/net2share/vaydns/client"
 	"github.com/net2share/vaydns/dns"
 	"github.com/net2share/vaydns/noise"
+	"github.com/net2share/vaydns/turbotunnel"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -54,6 +55,8 @@ func main() {
 	var compatDnstt bool
 	var clientIDSize int
 	var recordTypeStr string
+	var queueSize int
+	var kcpWindowSize int
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), `Usage:
@@ -114,6 +117,8 @@ Known TLS fingerprints for -utls are:
 	flag.BoolVar(&compatDnstt, "dnstt-compat", false, "use original dnstt wire format (8-byte ClientID, padding prefixes)")
 	flag.IntVar(&clientIDSize, "clientid-size", 2, "client ID size in bytes (ignored when -dnstt-compat is set)")
 	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt, cname, a, aaaa, mx, ns, srv)")
+	flag.IntVar(&queueSize, "queue-size", turbotunnel.QueueSize, "packet queue size for transport and DNS layers")
+	flag.IntVar(&kcpWindowSize, "kcp-window-size", 0, "KCP send/receive window size in packets (0 = queue-size/2)")
 
 	var logLevel string
 	flag.StringVar(&logLevel, "log-level", "info", "log level (debug, info, warning, error)")
@@ -265,6 +270,24 @@ Known TLS fingerprints for -utls are:
 		fmt.Fprintf(os.Stderr, "-open-stream-timeout (%s) must be greater than 0\n", openStreamTimeout)
 		os.Exit(1)
 	}
+	if queueSize <= 0 {
+		fmt.Fprintf(os.Stderr, "-queue-size (%d) must be greater than 0\n", queueSize)
+		os.Exit(1)
+	}
+	if kcpWindowSize < 0 {
+		fmt.Fprintf(os.Stderr, "-kcp-window-size (%d) must be >= 0\n", kcpWindowSize)
+		os.Exit(1)
+	}
+	if kcpWindowSize == 0 {
+		kcpWindowSize = queueSize / 2
+		if kcpWindowSize < 1 {
+			kcpWindowSize = 1
+		}
+	}
+	if kcpWindowSize > queueSize {
+		fmt.Fprintf(os.Stderr, "-kcp-window-size (%d) must be <= -queue-size (%d)\n", kcpWindowSize, queueSize)
+		os.Exit(1)
+	}
 
 	// Apply -dnstt-compat overrides.
 	if compatDnstt {
@@ -337,6 +360,9 @@ Known TLS fingerprints for -utls are:
 	tunnel.ReconnectMinDelay = reconnectMinDelay
 	tunnel.ReconnectMaxDelay = reconnectMaxDelay
 	tunnel.SessionCheckInterval = sessionCheckInterval
+	tunnel.PacketQueueSize = queueSize
+	tunnel.KCPWindowSize = kcpWindowSize
+	log.Infof("transport config: queue-size=%d kcp-window-size=%d", queueSize, kcpWindowSize)
 
 	if compatDnstt {
 		log.Infof("wire config: clientid-size=8 compat=true")

--- a/vaydns-server/main.go
+++ b/vaydns-server/main.go
@@ -311,7 +311,7 @@ func acceptStreams(conn *kcp.UDPSession, privkey []byte, upstream string, idleTi
 
 // acceptSessions listens for incoming KCP connections and passes them to
 // acceptStreams.
-func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int, upstream string, idleTimeout time.Duration, keepAlive time.Duration) error {
+func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int, upstream string, idleTimeout time.Duration, keepAlive time.Duration, kcpWindowSize int) error {
 	for {
 		conn, err := ln.AcceptKCP()
 		if err != nil {
@@ -331,7 +331,7 @@ func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int, upstream string, 
 			0, // default resend
 			1, // nc=1 => congestion window off
 		)
-		conn.SetWindowSize(turbotunnel.QueueSize/2, turbotunnel.QueueSize/2)
+		conn.SetWindowSize(kcpWindowSize, kcpWindowSize)
 		if rc := conn.SetMtu(mtu); !rc {
 			panic(rc)
 		}
@@ -1101,7 +1101,7 @@ func computeMaxEncodedPayloadMultiRR(limit int, chunkSize int) int {
 	return low
 }
 
-func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketConn, fallbackAddr *net.UDPAddr, idleTimeout time.Duration, keepAlive time.Duration, wireConfig turbotunnel.WireConfig) error {
+func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketConn, fallbackAddr *net.UDPAddr, idleTimeout time.Duration, keepAlive time.Duration, queueSize int, kcpWindowSize int, wireConfig turbotunnel.WireConfig) error {
 	defer dnsConn.Close()
 
 	log.Infof("pubkey %x", noise.PubkeyFromPrivkey(privkey))
@@ -1135,14 +1135,14 @@ func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketCon
 	log.Infof("effective MTU %d", mtu)
 
 	// Start up the virtual PacketConn for turbotunnel.
-	ttConn := turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, idleTimeout*2)
+	ttConn := turbotunnel.NewQueuePacketConn(turbotunnel.DummyAddr{}, idleTimeout*2, queueSize)
 	ln, err := kcp.ServeConn(nil, 0, 0, ttConn)
 	if err != nil {
 		return fmt.Errorf("opening KCP listener: %v", err)
 	}
 	defer ln.Close()
 	go func() {
-		err := acceptSessions(ln, privkey, mtu, upstream, idleTimeout, keepAlive)
+		err := acceptSessions(ln, privkey, mtu, upstream, idleTimeout, keepAlive, kcpWindowSize)
 		if err != nil {
 			log.Warnf("acceptSessions: %v", err)
 		}
@@ -1193,6 +1193,8 @@ func main() {
 	var compatDnstt bool
 	var clientIDSize int
 	var recordTypeStr string
+	var queueSize int
+	var kcpWindowSize int
 
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), `Usage:
@@ -1226,6 +1228,8 @@ Example:
 	flag.BoolVar(&compatDnstt, "dnstt-compat", false, "use original dnstt wire format (8-byte ClientID, padding prefixes)")
 	flag.IntVar(&clientIDSize, "clientid-size", 2, "client ID size in bytes (ignored when -dnstt-compat is set)")
 	flag.StringVar(&recordTypeStr, "record-type", "txt", "DNS record type for downstream data (txt, cname, a, aaaa, mx, ns, srv)")
+	flag.IntVar(&queueSize, "queue-size", turbotunnel.QueueSize, "packet queue size for DNS tunnel transport")
+	flag.IntVar(&kcpWindowSize, "kcp-window-size", 0, "KCP send/receive window size in packets (0 = queue-size/2)")
 
 	var logLevel string
 	flag.StringVar(&logLevel, "log-level", "info", "log level (debug, info, warning, error)")
@@ -1374,6 +1378,25 @@ Example:
 			fmt.Fprintf(os.Stderr, "-keepalive (%s) must be less than -idle-timeout (%s)\n", keepAlive, idleTimeout)
 			os.Exit(1)
 		}
+		if queueSize <= 0 {
+			fmt.Fprintf(os.Stderr, "-queue-size (%d) must be greater than 0\n", queueSize)
+			os.Exit(1)
+		}
+		if kcpWindowSize < 0 {
+			fmt.Fprintf(os.Stderr, "-kcp-window-size (%d) must be >= 0\n", kcpWindowSize)
+			os.Exit(1)
+		}
+		if kcpWindowSize == 0 {
+			kcpWindowSize = queueSize / 2
+			if kcpWindowSize < 1 {
+				kcpWindowSize = 1
+			}
+		}
+		if kcpWindowSize > queueSize {
+			fmt.Fprintf(os.Stderr, "-kcp-window-size (%d) must be <= -queue-size (%d)\n", kcpWindowSize, queueSize)
+			os.Exit(1)
+		}
+		log.Infof("transport config: queue-size=%d kcp-window-size=%d", queueSize, kcpWindowSize)
 
 		var wireConfig turbotunnel.WireConfig
 		if compatDnstt {
@@ -1418,7 +1441,7 @@ Example:
 			}
 		}
 
-		err = run(privkey, domain, upstream, dnsConn, fallbackAddr, idleTimeout, keepAlive, wireConfig)
+		err = run(privkey, domain, upstream, dnsConn, fallbackAddr, idleTimeout, keepAlive, queueSize, kcpWindowSize, wireConfig)
 		if err != nil {
 			log.Fatalf("%v", err)
 		}


### PR DESCRIPTION
## Summary

Add `-queue-size` and `-kcp-window-size` runtime flags to both client and server, and fix a potential server panic from a race condition in RemoteMap.

## What changed

### Runtime transport sizing flags

Both `vaydns-client` and `vaydns-server` now accept:

- `-queue-size N` (default: 512) — packet queue capacity for transport and DNS layers
- `-kcp-window-size N` (default: queue-size/2) — KCP send/receive window size

The queue size controls the buffered channel capacity between KCP and the DNS transport. The KCP window size controls how many unacknowledged packets KCP can have in flight. Default of `queue-size/2` leaves headroom for retransmissions.

Validation:
- `queue-size` must be > 0
- `kcp-window-size` must be >= 0 (0 = auto = queue-size/2)
- `kcp-window-size` must be <= `queue-size`

Both binaries log the effective transport config at startup:
```
transport config: queue-size=512 kcp-window-size=256
```

### RemoteMap race condition fix (server-side)

Fixed a potential panic where `WriteTo` could send on a closed channel. The race:
1. `WriteTo` calls `SendQueue(addr)`, gets the channel, releases the map lock
2. Between lock release and the `select` write, `removeExpired` closes the channel
3. Sending on a closed channel panics, crashing the server

Fix: added a `sendMu` mutex and `expired` flag to each remote record. `removeExpired` sets `expired = true` under `sendMu` before closing. `WriteTo` holds `sendMu` while writing, and retries with a fresh record if the old one expired.

### Constructor signature changes

`NewQueuePacketConn`, `NewRemoteMap`, and all transport constructors (`NewUDPPacketConn`, `NewHTTPPacketConn`, `NewTLSPacketConn`, `NewDNSPacketConn`) now accept a `queueSize int` parameter. This is an internal change — the public client API (`client.Tunnel`) is unchanged; new `PacketQueueSize` and `KCPWindowSize` fields default to zero (use defaults).

## Files

- `turbotunnel/consts.go` — unchanged, `QueueSize = 512` remains the default
- `turbotunnel/remotemap.go` — `queueSize` field, `sendMu`/`expired` race fix
- `turbotunnel/queuepacketconn.go` — `queueSize` parameter, safe `WriteTo`
- `client/client.go` — `PacketQueueSize`/`KCPWindowSize` fields, effective* helpers
- `client/dns.go` — pass `queueSize` through
- `client/http.go` — pass `queueSize` through
- `client/tls.go` — pass `queueSize` through
- `client/udp.go` — pass `queueSize` through
- `vaydns-client/main.go` — flags, validation, wiring
- `vaydns-server/main.go` — flags, validation, wiring