### PR TITLE
fix(server): bound server-side noise handshake

### DIFF
--- a/vaydns-server/main.go
+++ b/vaydns-server/main.go
@@ -75,6 +75,9 @@ import (
 const (
 	defaultIdleTimeout = 60 * time.Second
 	defaultKeepAlive   = 10 * time.Second
+	// Bound the pre-smux handshake so half-open KCP sessions cannot linger
+	// indefinitely and consume server resources.
+	defaultHandshakeTimeout = 15 * time.Second
 
 	// How to set the TTL field in Answer resource records.
 	responseTTL = 60
@@ -270,7 +273,7 @@ func handleStream(stream *smux.Stream, upstream string, conv uint32) error {
 // then awaits smux streams. It passes each stream to handleStream.
 func acceptStreams(conn *kcp.UDPSession, privkey []byte, upstream string, idleTimeout time.Duration, keepAlive time.Duration) error {
 	// Put a Noise channel on top of the KCP conn.
-	rw, err := noise.NewServer(conn, privkey)
+	rw, err := serverNoiseHandshake(conn, privkey, defaultHandshakeTimeout)
 	if err != nil {
 		return err
 	}
@@ -307,6 +310,18 @@ func acceptStreams(conn *kcp.UDPSession, privkey []byte, upstream string, idleTi
 			}
 		}()
 	}
+}
+
+// serverNoiseHandshake performs the server-side Noise handshake with a deadline.
+// This prevents half-open KCP sessions from hanging forever before smux starts.
+func serverNoiseHandshake(conn *kcp.UDPSession, privkey []byte, timeout time.Duration) (io.ReadWriteCloser, error) {
+	conn.SetDeadline(time.Now().Add(timeout))
+	rw, err := noise.NewServer(conn, privkey)
+	conn.SetDeadline(time.Time{}) // clear deadline after the handshake
+	if err != nil {
+		return nil, fmt.Errorf("noise handshake: %v", err)
+	}
+	return rw, nil
 }
 
 // acceptSessions listens for incoming KCP connections and passes them to


### PR DESCRIPTION
## Summary

This patch adds a deadline around the server-side Noise handshake.

Previously, the server could wait indefinitely in the handshake path after
accepting a KCP session. With this change, stalled or half-open handshakes time
out and the session is cleaned up.

## Problem

The server accepted a KCP session and then called `noise.NewServer(...)`
without any handshake deadline.

If a client stalled, disappeared, or only partially completed the handshake,
the server could keep that session alive indefinitely. Over time, these
half-open sessions could accumulate and make the server stop serving new
clients reliably even though the process was still running.

## Patch

- add a server-side handshake timeout constant
- wrap `noise.NewServer(...)` in a helper that applies a deadline
- clear the deadline immediately after a successful handshake
- return a wrapped error when the handshake fails

## Behavior

- successful handshakes behave the same as before
- stalled or half-open handshakes now fail instead of hanging forever
- failed handshake sessions are allowed to close and release resources

## Timeout Choice

The server uses a `15s` handshake timeout in this patch.

That matches the client's existing default handshake timeout, so the two sides
stay aligned without introducing a new knob in this PR.