### PR TITLE
fix(server): clarify server accept session/stream warning logs

### DIFF
--- a/vaydns-server/main.go
+++ b/vaydns-server/main.go
@@ -357,7 +357,7 @@ func acceptSessions(ln *kcp.Listener, privkey []byte, mtu int, upstream string, 
 			}()
 			err := acceptStreams(conn, privkey, upstream, idleTimeout, keepAlive)
 			if err != nil && !errors.Is(err, io.ErrClosedPipe) {
-				log.Warnf("session %08x acceptStreams: %v", conn.GetConv(), err)
+				log.Warnf("session %08x accept streams: %v", conn.GetConv(), err)
 			}
 		}()
 	}
@@ -1159,7 +1159,7 @@ func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketCon
 	go func() {
 		err := acceptSessions(ln, privkey, mtu, upstream, idleTimeout, keepAlive, kcpWindowSize)
 		if err != nil {
-			log.Warnf("acceptSessions: %v", err)
+			log.Warnf("accept sessions: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
## Summary

- replace internal helper names in server warning logs with shorter operator-facing wording
- keep the existing session ID and wrapped error values unchanged
- make the accept-loop warnings read like actions instead of implementation details

## Files

- `vaydns-server/main.go`
