### PR TITLE
fix(client): make max streams unlimited by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ sudo ip6tables -t nat -I PREROUTING -i eth0 -p udp --dport 53 -j REDIRECT --to-p
 | --------------------------- | -------------------------------------------------- | ------- |
 | `-idle-timeout D`           | Session idle timeout (must match server)                                                    | `60s`   |
 | `-keepalive D`              | Keepalive ping interval (must match server, must be < idle-timeout)                         | `10s`   |
-| `-max-streams N`            | Max concurrent streams per session (0 = unlimited)                                          | `256`   |
+| `-max-streams N`            | Max concurrent streams per session (0 = unlimited)                                          | `0`   |
 | `-open-stream-timeout D`    | Timeout for opening an smux stream                                                          | `10s`   |
 | `-reconnect-min D`          | Initial backoff delay for session reconnect                                                  | `1s`    |
 | `-reconnect-max D`          | Max backoff delay (must be >= reconnect-min)                                                 | `30s`   |

--- a/client/client.go
+++ b/client/client.go
@@ -30,13 +30,13 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-	utls "github.com/refraction-networking/utls"
-	"github.com/xtaci/kcp-go/v5"
-	"github.com/xtaci/smux"
 	"github.com/net2share/vaydns/dns"
 	"github.com/net2share/vaydns/noise"
 	"github.com/net2share/vaydns/turbotunnel"
+	utls "github.com/refraction-networking/utls"
+	log "github.com/sirupsen/logrus"
+	"github.com/xtaci/kcp-go/v5"
+	"github.com/xtaci/smux"
 )
 
 // Default timeouts for VayDNS mode.
@@ -47,10 +47,10 @@ const (
 	DefaultReconnectDelay       = 1 * time.Second
 	DefaultReconnectMaxDelay    = 30 * time.Second
 	DefaultSessionCheckInterval = 20 * time.Second
-	DefaultUDPResponseTimeout    = 500 * time.Millisecond
-	DefaultUDPWorkers            = 100
-	DefaultMaxStreams             = 256
-	DefaultHandshakeTimeout      = 15 * time.Second
+	DefaultUDPResponseTimeout   = 500 * time.Millisecond
+	DefaultUDPWorkers           = 100
+	DefaultMaxStreams           = 0 // unlimited
+	DefaultHandshakeTimeout     = 15 * time.Second
 )
 
 // Default timeouts for dnstt compatibility mode.
@@ -194,14 +194,14 @@ type Tunnel struct {
 	TunnelServer TunnelServer
 
 	// Session configuration. Zero values use defaults.
-	IdleTimeout          time.Duration // default: 10s (2m with DnsttCompat)
-	KeepAlive            time.Duration // default: 2s (10s with DnsttCompat)
-	OpenStreamTimeout    time.Duration // default: 10s
-	MaxStreams            int           // default: 256 (0 = unlimited)
-	ReconnectMinDelay    time.Duration // default: 1s
-	ReconnectMaxDelay    time.Duration // default: 30s
-	SessionCheckInterval time.Duration // default: 20s
-	HandshakeTimeout     time.Duration // default: 30s
+	IdleTimeout          time.Duration                 // default: 10s (2m with DnsttCompat)
+	KeepAlive            time.Duration                 // default: 2s (10s with DnsttCompat)
+	OpenStreamTimeout    time.Duration                 // default: 10s
+	MaxStreams           int                           // default: 0 (0 = unlimited)
+	ReconnectMinDelay    time.Duration                 // default: 1s
+	ReconnectMaxDelay    time.Duration                 // default: 30s
+	SessionCheckInterval time.Duration                 // default: 20s
+	HandshakeTimeout     time.Duration                 // default: 30s
 	PacketQueueSize      int                           // default: QueueSize (512)
 	KCPWindowSize        int                           // default: PacketQueueSize/2
 	QueueOverflowMode    turbotunnel.QueueOverflowMode // default: drop


### PR DESCRIPTION
  ## Summary

  - change the client default MaxStreams value from 256 to 0
  - use the existing 0 = unlimited behavior as the default
  - keep the stream limit only when MaxStreams is explicitly set to a positive value
  
  ## Files
  - `client/client.go`
  - `README.md`