### PR TITLE
feat: add -v flag for printing version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           go-version: '1.24'
 
       - name: Build
-        run: CGO_ENABLED=0 go build -v ./...
+        run: CGO_ENABLED=0 go build -v -ldflags="-X main.version=${GITHUB_SHA::7}" ./...
 
       - name: Test
         run: go test -v ./...
@@ -70,8 +70,9 @@ jobs:
             ARCH="armv7"
           fi
           SUFFIX="${{ matrix.suffix }}"
-          go build -trimpath -ldflags="-s -w" -o "vaydns-client-${{ matrix.goos }}-${ARCH}${SUFFIX}" ./vaydns-client
-          go build -trimpath -ldflags="-s -w" -o "vaydns-server-${{ matrix.goos }}-${ARCH}${SUFFIX}" ./vaydns-server
+          VERSION="${GITHUB_SHA::7}"
+          go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o "vaydns-client-${{ matrix.goos }}-${ARCH}${SUFFIX}" ./vaydns-client
+          go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o "vaydns-server-${{ matrix.goos }}-${ARCH}${SUFFIX}" ./vaydns-server
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -119,5 +120,6 @@ jobs:
           context: .
           file: Dockerfile
           push: true
+          build-args: VERSION=dev-${{ env.SHORT_SHA }}
           tags: ghcr.io/${{ github.repository }}:dev-${{ env.SHORT_SHA }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -78,8 +78,10 @@ jobs:
             ARCH="armv7"
           fi
           SUFFIX="${{ matrix.suffix }}"
-          go build -trimpath -ldflags="-s -w" -o "vaydns-client-${{ matrix.goos }}-${ARCH}${SUFFIX}" ./vaydns-client
-          go build -trimpath -ldflags="-s -w" -o "vaydns-server-${{ matrix.goos }}-${ARCH}${SUFFIX}" ./vaydns-server
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          VERSION="${TAG#v}"
+          go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o "vaydns-client-${{ matrix.goos }}-${ARCH}${SUFFIX}" ./vaydns-client
+          go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o "vaydns-server-${{ matrix.goos }}-${ARCH}${SUFFIX}" ./vaydns-server
           chmod +x vaydns-client-* vaydns-server-*
 
       - name: Upload artifact
@@ -148,6 +150,7 @@ jobs:
           context: .
           file: Dockerfile
           push: true
+          build-args: VERSION=${{ steps.version.outputs.VERSION }}
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
             ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /vaydns-server ./vaydns-server
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /vaydns-client ./vaydns-client
+ARG VERSION=dev
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o /vaydns-server ./vaydns-server
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" -o /vaydns-client ./vaydns-client
 
 FROM alpine
 RUN apk add --no-cache curl

--- a/vaydns-client/main.go
+++ b/vaydns-client/main.go
@@ -20,6 +20,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var version = "dev"
+
 func readKeyFromFile(filename string) ([]byte, error) {
 	f, err := os.Open(filename)
 	if err != nil {
@@ -30,6 +32,7 @@ func readKeyFromFile(filename string) ([]byte, error) {
 }
 
 func main() {
+	var showVersion bool
 	var dohURL string
 	var dotAddr string
 	var domainArg string
@@ -140,7 +143,13 @@ Known TLS fingerprints for -utls are:
 
 	var logLevel string
 	flag.StringVar(&logLevel, "log-level", "info", "log level (debug, info, warning, error)")
+	flag.BoolVar(&showVersion, "v", false, "print version and exit")
 	flag.Parse()
+
+	if showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	level, err := log.ParseLevel(logLevel)
 	if err != nil {

--- a/vaydns-server/main.go
+++ b/vaydns-server/main.go
@@ -1194,7 +1194,10 @@ func run(privkey []byte, domain dns.Name, upstream string, dnsConn net.PacketCon
 	return recvLoop(domain, dnsConn, ttConn, ch, fallbackMgr, stats, wireConfig)
 }
 
+var version = "dev"
+
 func main() {
+	var showVersion bool
 	var genKey bool
 	var domainArg string
 	var upstream string
@@ -1250,7 +1253,13 @@ Example:
 
 	var logLevel string
 	flag.StringVar(&logLevel, "log-level", "info", "log level (debug, info, warning, error)")
+	flag.BoolVar(&showVersion, "v", false, "print version and exit")
 	flag.Parse()
+
+	if showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
 
 	level, err := log.ParseLevel(logLevel)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `-v` flag to both client and server to print version and exit
- Inject version via `-X main.version` ldflags in CI, release, and Docker builds
- Defaults to `dev` for local builds

Closes #69